### PR TITLE
disable the list item and display an altative to the name

### DIFF
--- a/src/components/FoodListItem.vue
+++ b/src/components/FoodListItem.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="food-list-item">
-    <v-list-item @click="$emit('click', food)">
-      <v-list-item-title>{{ food.name }}</v-list-item-title>
+    <v-list-item :disabled="!food.name" @click="$emit('click', food)">
+      <v-list-item-title>{{
+        food.name || 'This food item is being created, please check back later.'
+      }}</v-list-item-title>
       <v-list-item-subtitle class="d-flex flex-column ga-1">
         <div v-if="food.brand">{{ food.brand }}</div>
         <div v-else>No specific brand</div>

--- a/src/components/__tests__/FoodListItem.spec.ts
+++ b/src/components/__tests__/FoodListItem.spec.ts
@@ -95,10 +95,18 @@ describe('Food List Item Component', () => {
 
   it('emits click event when the item is clicked', async () => {
     wrapper = createWrapper();
-    const updateButton = wrapper.findComponent({ name: 'VListItem' });
-    await updateButton.trigger('click');
+    const listItem = wrapper.findComponent({ name: 'VListItem' });
+    await listItem.trigger('click');
     expect(wrapper.emitted('click')).toBeTruthy();
     expect(wrapper.emitted('click')).toHaveLength(1);
     expect(wrapper.emitted('click')?.[0]).toEqual([BANANA]);
+  });
+
+  describe('when displaying items still being built in the background', () => {
+    it('displays an alternate name', () => {
+      wrapper = createWrapper({ food: { id: '299r0r990293', fdcId: 21249934 } });
+      const title = wrapper.findComponent({ name: 'VListItemTitle' });
+      expect(title.text()).toBe('This food item is being created, please check back later.');
+    });
   });
 });


### PR DESCRIPTION
A food item that does not have a name is a sign that the item itself is one that is being built by Firebase and it is still under construction. When it is complete, it will get a name. If it cannot be completed, Firebase will remove it.