### PR TITLE
ensures id is passed during meal plan update

### DIFF
--- a/src/data/__mocks__/meal-plans.ts
+++ b/src/data/__mocks__/meal-plans.ts
@@ -10,7 +10,7 @@ interface MealPlansData {
   getMealPlan: (id: string) => Promise<MealPlan | null>;
   getMealPlanForDate: (dt: string) => Promise<MealPlan | null>;
   removeMealPlan: (id: string) => Promise<void>;
-  updateMealPlan: (mealPlan: MealPlan) => Promise<void>;
+  updateMealPlan: (id: string, fields: Omit<MealPlan, 'id'>) => Promise<void>;
 }
 
 const addMealPlan = vi.fn();

--- a/src/data/__tests__/meal-plans.spec.ts
+++ b/src/data/__tests__/meal-plans.spec.ts
@@ -120,20 +120,14 @@ describe('Meal Plans Data Service', () => {
   describe('update meal plan', () => {
     it('obtains a reference to the doc', () => {
       const { updateMealPlan } = useMealPlansData();
-      updateMealPlan({
-        ...TEST_MEAL_PLAN,
-        id: '43334-22343-893',
-      });
+      updateMealPlan('43334-22343-893', TEST_MEAL_PLAN);
       expect(doc).toHaveBeenCalledOnce();
       expect(doc).toHaveBeenCalledWith({ id: 42, name: 'my fake fire store' }, 'meal-plans/43334-22343-893');
     });
 
     it('updates the meal plan document', () => {
       const { updateMealPlan } = useMealPlansData();
-      updateMealPlan({
-        ...TEST_MEAL_PLAN,
-        id: '43334-22343-893',
-      });
+      updateMealPlan('43334-22343-893', TEST_MEAL_PLAN);
       expect(updateDoc).toHaveBeenCalledOnce();
       expect(updateDoc).toHaveBeenCalledWith('42:doc:meal-plans/43334-22343-893', {
         ...TEST_MEAL_PLAN,

--- a/src/data/meal-plans.ts
+++ b/src/data/meal-plans.ts
@@ -24,11 +24,7 @@ export const useMealPlansData = () => {
     await deleteDoc(doc(db, `${path}/${id}`));
   };
 
-  const updateMealPlan = async (mealPlan: MealPlan): Promise<void> => {
-    const { id, ...fields } = mealPlan;
-    if (!id) {
-      throw new Error('Meal plan id is required to update');
-    }
+  const updateMealPlan = async (id: string, fields: Omit<MealPlan, 'id'>): Promise<void> => {
     await updateDoc(doc(db, `${path}/${id}`), fields);
   };
 

--- a/src/pages/planning/__tests__/day.spec.ts
+++ b/src/pages/planning/__tests__/day.spec.ts
@@ -1210,8 +1210,7 @@ describe('day', () => {
         await button.trigger('click');
         const { updateMealPlan, addMealPlan } = useMealPlansData();
         expect(addMealPlan).not.toHaveBeenCalled();
-        expect(updateMealPlan).toHaveBeenCalledExactlyOnceWith({
-          id: FULL_MEAL_PLAN.id,
+        expect(updateMealPlan).toHaveBeenCalledExactlyOnceWith(FULL_MEAL_PLAN.id, {
           date: '2026-02-18',
           meals: [modifiedBreakfast, FULL_MEAL_PLAN.meals[1], FULL_MEAL_PLAN.meals[2], FULL_MEAL_PLAN.meals[3]],
         });

--- a/src/pages/planning/day.vue
+++ b/src/pages/planning/day.vue
@@ -255,7 +255,8 @@ const saveDayPlan = async () => {
   if (dinner.value.item) meals.push(dinner.value.item);
   if (snack.value.item) meals.push(snack.value.item);
   if (mealPlan.value.id) {
-    await updateMealPlan({ ...mealPlan.value, id: mealPlan.value.id, meals });
+    const { id, ...planFields } = mealPlan.value;
+    await updateMealPlan(id, { ...planFields, meals });
   } else {
     await addMealPlan({ ...mealPlan.value, meals });
   }


### PR DESCRIPTION
Explicitly includes the meal plan ID when updating,
addressing an issue where updates were failing due to
a missing ID parameter.
