### PR TITLE
Emit fine-grained meal-changed events from MealEditor

### DIFF
--- a/src/components/meals/MealEditor.vue
+++ b/src/components/meals/MealEditor.vue
@@ -48,7 +48,7 @@
     </v-card-text>
     <v-card-actions>
       <v-spacer />
-      <CloseButton class="mr-4" @click="$emit('cancel')" />
+      <CloseButton class="mr-4" @click="$emit('close')" />
     </v-card-actions>
   </v-card>
 
@@ -69,7 +69,7 @@ import type { Meal, MealItem } from '@/models/meal';
 import { computed, ref } from 'vue';
 
 const emit = defineEmits<{
-  (event: 'cancel'): void;
+  (event: 'close'): void;
   (event: 'meal-changed', value: Meal): void;
 }>();
 const props = defineProps<{ meal: Meal }>();

--- a/src/components/meals/MealEditor.vue
+++ b/src/components/meals/MealEditor.vue
@@ -48,8 +48,7 @@
     </v-card-text>
     <v-card-actions>
       <v-spacer />
-      <CancelButton class="mr-4" @click="$emit('cancel')" />
-      <SaveButton :disabled="!isModified || isEditing" @click="save" />
+      <CloseButton class="mr-4" @click="$emit('cancel')" />
     </v-card-actions>
   </v-card>
 
@@ -70,7 +69,6 @@ import type { Meal, MealItem } from '@/models/meal';
 import { computed, ref } from 'vue';
 
 const emit = defineEmits<{
-  (event: 'save', payload: Meal): void;
   (event: 'cancel'): void;
   (event: 'meal-changed', value: Meal): void;
 }>();
@@ -81,13 +79,8 @@ const { recipes } = useRecipesData();
 const recipeMealItem = ref<Partial<MealItem> | null>(null);
 const mealItemToRemove = ref<MealItem | null>(null);
 const mealItems = ref<EditableItem<MealItem>[]>(props.meal.items.map((item) => ({ isEditing: false, item })));
-const isModified = ref(false);
 
 const showConfirmDialog = ref(false);
-
-const isEditing = computed(() => {
-  return mealItems.value.some((wrappedItem) => wrappedItem.isEditing) || recipeMealItem.value !== null;
-});
 
 const recipeMealItems = computed((): EditableItem<MealItem>[] =>
   mealItems.value.filter((wrappedItem) => wrappedItem.item.recipeId !== undefined),
@@ -134,18 +127,12 @@ const createMealItem = (item: MealItem) => {
   if (item.recipeId) {
     recipeMealItem.value = null;
   }
-  isModified.value = true;
   emit('meal-changed', currentMeal());
 };
 
 const updateMealItem = (wrapper: EditableItem<MealItem>, item: MealItem) => {
   wrapper.item = item;
   wrapper.isEditing = false;
-  isModified.value = true;
   emit('meal-changed', currentMeal());
-};
-
-const save = () => {
-  emit('save', currentMeal());
 };
 </script>

--- a/src/components/meals/MealEditor.vue
+++ b/src/components/meals/MealEditor.vue
@@ -69,7 +69,11 @@ import type { EditableItem } from '@/models/editable-item';
 import type { Meal, MealItem } from '@/models/meal';
 import { computed, ref } from 'vue';
 
-const emit = defineEmits<{ (event: 'save', payload: Meal): void; (event: 'cancel'): void }>();
+const emit = defineEmits<{
+  (event: 'save', payload: Meal): void;
+  (event: 'cancel'): void;
+  (event: 'meal-changed', value: Meal): void;
+}>();
 const props = defineProps<{ meal: Meal }>();
 
 const { recipes } = useRecipesData();
@@ -111,12 +115,18 @@ const askToDelete = (item: EditableItem<MealItem>) => {
   showConfirmDialog.value = true;
 };
 
+const currentMeal = (): Meal => ({
+  ...props.meal,
+  items: mealItems.value.map((wrappedItem) => wrappedItem.item),
+});
+
 const removeMealItem = () => {
   if (mealItemToRemove.value) {
     mealItems.value = mealItems.value.filter((wrappedItem) => wrappedItem.item !== mealItemToRemove.value);
   }
   mealItemToRemove.value = null;
   showConfirmDialog.value = false;
+  emit('meal-changed', currentMeal());
 };
 
 const createMealItem = (item: MealItem) => {
@@ -125,19 +135,17 @@ const createMealItem = (item: MealItem) => {
     recipeMealItem.value = null;
   }
   isModified.value = true;
+  emit('meal-changed', currentMeal());
 };
 
 const updateMealItem = (wrapper: EditableItem<MealItem>, item: MealItem) => {
   wrapper.item = item;
   wrapper.isEditing = false;
   isModified.value = true;
+  emit('meal-changed', currentMeal());
 };
 
 const save = () => {
-  const mealToSave: Meal = {
-    ...props.meal,
-    items: mealItems.value.map((wrappedItem) => wrappedItem.item),
-  };
-  emit('save', mealToSave);
+  emit('save', currentMeal());
 };
 </script>

--- a/src/components/meals/__tests__/MealEditor.spec.ts
+++ b/src/components/meals/__tests__/MealEditor.spec.ts
@@ -78,11 +78,11 @@ describe('Meal Editor', () => {
     expect(wrapper.findAllComponents({ name: 'MealItemEditorCard' }).length).toBe(0);
   });
 
-  it('emits cancel when the close button is clicked', async () => {
+  it('emits close when the close button is clicked', async () => {
     wrapper = mountComponent({ meal: emptyMeal });
     const closeButton = wrapper.findComponent('[data-testid="close-button"]');
     await closeButton.trigger('click');
-    expect(wrapper.emitted('cancel')).toBeDefined();
+    expect(wrapper.emitted('close')).toBeDefined();
   });
 
   describe('adding to an empty meal', () => {

--- a/src/components/meals/__tests__/MealEditor.spec.ts
+++ b/src/components/meals/__tests__/MealEditor.spec.ts
@@ -270,6 +270,26 @@ describe('Meal Editor', () => {
         expect(nutritionDisplay.props('value')).toEqual(updatedItem.nutrition);
       });
 
+      it('emits meal-changed with the updated meal when save is clicked', async () => {
+        const modifyButton = panel.findComponent('[data-testid="modify-button"]');
+        await modifyButton.trigger('click');
+        const mealItemEditor = panel.findComponent({ name: 'MealItemEditorCard' });
+
+        const originalItem = TEST_MEAL.items.find((item) => item.recipeId);
+        if (!originalItem) throw new Error('TEST_MEAL should contain at least one recipe item');
+
+        const updatedItem = { ...originalItem, name: 'Updated Recipe Name' };
+        await mealItemEditor.vm.$emit('save', updatedItem);
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.emitted('meal-changed')).toBeDefined();
+        const emittedMeal = (wrapper.emitted('meal-changed') as unknown[][])[0]![0] as Meal;
+        expect(emittedMeal).toEqual({
+          ...TEST_MEAL,
+          items: TEST_MEAL.items.map((item) => (item === originalItem ? updatedItem : item)),
+        });
+      });
+
       it('restores the nutritional information when cancel is clicked', async () => {
         const modifyButton = panel.findComponent('[data-testid="modify-button"]');
         await modifyButton.trigger('click');
@@ -289,6 +309,26 @@ describe('Meal Editor', () => {
         await wrapper.vm.$nextTick();
         const confirmDialog = wrapper.findComponent({ name: 'ConfirmDialog' });
         expect(confirmDialog.exists()).toBe(true);
+      });
+
+      it('emits meal-changed with the updated meal when deletion is confirmed', async () => {
+        const originalItem = TEST_MEAL.items.find((item) => item.recipeId);
+        if (!originalItem) throw new Error('TEST_MEAL should contain at least one recipe item');
+
+        const deleteButton = panel.findComponent('[data-testid="delete-button"]');
+        await deleteButton.trigger('click');
+        await wrapper.vm.$nextTick();
+
+        const confirmDialog = wrapper.findComponent({ name: 'ConfirmDialog' });
+        await confirmDialog.vm.$emit('confirm');
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.emitted('meal-changed')).toBeDefined();
+        const emittedMeal = (wrapper.emitted('meal-changed') as unknown[][])[0]![0] as Meal;
+        expect(emittedMeal).toEqual({
+          ...TEST_MEAL,
+          items: TEST_MEAL.items.filter((item) => item !== originalItem),
+        });
       });
 
       it('removes the recipe from the list when deletion is confirmed', async () => {
@@ -402,6 +442,18 @@ describe('Meal Editor', () => {
           const recipePanels = wrapper.findComponent('[data-testid="recipe-panels"]');
           const panels = recipePanels.findAllComponents(components.VExpansionPanel);
           expect(panels.length).toBe(1);
+        });
+
+        it('emits meal-changed with the updated meal', async () => {
+          wrapper = mountComponent({ meal: emptyMeal });
+          const addRecipeButton = wrapper.findComponent('[data-testid="add-recipe-button"]');
+          await addRecipeButton.trigger('click');
+          const mealItemEditors = wrapper.findAllComponents({ name: 'MealItemEditorCard' });
+          await mealItemEditors[0]!.vm.$emit('save', recipeMealItem);
+          await wrapper.vm.$nextTick();
+          expect(wrapper.emitted('meal-changed')).toBeDefined();
+          const emittedMeal = (wrapper.emitted('meal-changed') as unknown[][])[0]![0] as Meal;
+          expect(emittedMeal).toEqual({ ...emptyMeal, items: [recipeMealItem] });
         });
       });
     });

--- a/src/components/meals/__tests__/MealEditor.spec.ts
+++ b/src/components/meals/__tests__/MealEditor.spec.ts
@@ -270,7 +270,7 @@ describe('Meal Editor', () => {
         expect(nutritionDisplay.props('value')).toEqual(updatedItem.nutrition);
       });
 
-      it('emits meal-changed with the updated meal when save is clicked', async () => {
+      it('emits meal-changed with the updated meal when the meal item editor saves an updated item', async () => {
         const modifyButton = panel.findComponent('[data-testid="modify-button"]');
         await modifyButton.trigger('click');
         const mealItemEditor = panel.findComponent({ name: 'MealItemEditorCard' });

--- a/src/components/meals/__tests__/MealEditor.spec.ts
+++ b/src/components/meals/__tests__/MealEditor.spec.ts
@@ -78,6 +78,13 @@ describe('Meal Editor', () => {
     expect(wrapper.findAllComponents({ name: 'MealItemEditorCard' }).length).toBe(0);
   });
 
+  it('emits cancel when the close button is clicked', async () => {
+    wrapper = mountComponent({ meal: emptyMeal });
+    const closeButton = wrapper.findComponent('[data-testid="close-button"]');
+    await closeButton.trigger('click');
+    expect(wrapper.emitted('cancel')).toBeDefined();
+  });
+
   describe('adding to an empty meal', () => {
     beforeEach(() => (wrapper = mountComponent({ meal: emptyMeal })));
 
@@ -85,40 +92,6 @@ describe('Meal Editor', () => {
       const recipePanels = wrapper.findComponent('[data-testid="recipe-panels"]');
       const panels = recipePanels.findAllComponents(components.VExpansionPanel);
       expect(panels.length).toBe(0);
-    });
-
-    describe('save button', () => {
-      it('starts disabled', () => {
-        const saveButton = wrapper.findComponent('[data-testid="save-button"]');
-        expect(saveButton.exists()).toBe(true);
-        expect(saveButton.attributes('disabled')).toBeDefined();
-      });
-
-      it('is enabled after a recipe is added', async () => {
-        const saveButton = wrapper.findComponent('[data-testid="save-button"]');
-        const addRecipeButton = wrapper.findComponent('[data-testid="add-recipe-button"]');
-        await addRecipeButton.trigger('click');
-        const mealItemEditors = wrapper.findAllComponents({ name: 'MealItemEditorCard' });
-        await mealItemEditors[0]!.vm.$emit('save', recipeMealItem);
-        await wrapper.vm.$nextTick();
-        expect(saveButton.attributes('disabled')).toBeUndefined();
-      });
-
-      it('emits the save event with the meal data when clicked', async () => {
-        const saveButton = wrapper.findComponent('[data-testid="save-button"]');
-        const addRecipeButton = wrapper.findComponent('[data-testid="add-recipe-button"]');
-        await addRecipeButton.trigger('click');
-        const updatedMealItemEditors = wrapper.findAllComponents({ name: 'MealItemEditorCard' });
-        await updatedMealItemEditors[0]!.vm.$emit('save', recipeMealItem);
-        await wrapper.vm.$nextTick();
-        await saveButton.trigger('click');
-        expect(wrapper.emitted('save')).toBeDefined();
-        const emittedMeal = (wrapper.emitted('save') as unknown[][])[0]![0] as Meal;
-        expect(emittedMeal).toEqual({
-          ...emptyMeal,
-          items: [recipeMealItem],
-        });
-      });
     });
   });
 
@@ -129,69 +102,6 @@ describe('Meal Editor', () => {
       const recipePanels = wrapper.findComponent('[data-testid="recipe-panels"]');
       const panels = recipePanels.findAllComponents(components.VExpansionPanel);
       expect(panels.length).toBe(TEST_MEAL.items.filter((item) => item.recipeId).length);
-    });
-
-    describe('save button', () => {
-      it('starts disabled', () => {
-        const saveButton = wrapper.findComponent('[data-testid="save-button"]');
-        expect(saveButton.exists()).toBe(true);
-        expect(saveButton.attributes('disabled')).toBeDefined();
-      });
-
-      it('is enabled after a recipe is added', async () => {
-        const saveButton = wrapper.findComponent('[data-testid="save-button"]');
-        const addRecipeButton = wrapper.findComponent('[data-testid="add-recipe-button"]');
-        await addRecipeButton.trigger('click');
-        const mealItemEditors = wrapper.findAllComponents({ name: 'MealItemEditorCard' });
-        await mealItemEditors[0]!.vm.$emit('save', recipeMealItem);
-        await wrapper.vm.$nextTick();
-        expect(saveButton.attributes('disabled')).toBeUndefined();
-      });
-
-      it('is enabled after an existing recipe is updated', async () => {
-        const saveButton = wrapper.findComponent('[data-testid="save-button"]');
-        const recipePanels = wrapper.findComponent('[data-testid="recipe-panels"]');
-        const panels = recipePanels.findAllComponents(components.VExpansionPanel);
-        const panel = panels[0]!;
-        const header = panel.findComponent(components.VExpansionPanelTitle);
-        await header.trigger('click');
-        const modifyButton = panel.findComponent('[data-testid="modify-button"]');
-        await modifyButton.trigger('click');
-        const mealItemEditor = panel.findComponent({ name: 'MealItemEditorCard' });
-        await mealItemEditor.vm.$emit('save', {
-          ...recipeMealItem,
-          name: 'Updated Recipe Name',
-        });
-        await wrapper.vm.$nextTick();
-        expect(saveButton.attributes('disabled')).toBeUndefined();
-      });
-
-      it('is disabled if a recipe is open for edit', async () => {
-        // first enable the button by adding a recipe
-        const saveButton = wrapper.findComponent('[data-testid="save-button"]');
-        const addRecipeButton = wrapper.findComponent('[data-testid="add-recipe-button"]');
-        await addRecipeButton.trigger('click');
-        const mealItemEditors = wrapper.findAllComponents({ name: 'MealItemEditorCard' });
-        await mealItemEditors[0]!.vm.$emit('save', recipeMealItem);
-        await wrapper.vm.$nextTick();
-        expect(saveButton.attributes('disabled')).toBeUndefined();
-        // Now open an existing recipe for edit
-        const recipePanels = wrapper.findComponent('[data-testid="recipe-panels"]');
-        const panels = recipePanels.findAllComponents(components.VExpansionPanel);
-        const panel = panels[0]!;
-        const header = panel.findComponent(components.VExpansionPanelTitle);
-        await header.trigger('click');
-        const modifyButton = panel.findComponent('[data-testid="modify-button"]');
-        await modifyButton.trigger('click');
-        await wrapper.vm.$nextTick();
-        expect(saveButton.attributes('disabled')).toBeDefined();
-        // Cancel the edit and show the button is enabled again
-        const mealItemEditor = panel.findComponent({ name: 'MealItemEditorCard' });
-        const cancelButton = mealItemEditor.findComponent('[data-testid="cancel-button"]');
-        await cancelButton.trigger('click');
-        await wrapper.vm.$nextTick();
-        expect(saveButton.attributes('disabled')).toBeUndefined();
-      });
     });
 
     describe('an existing recipe meal item', () => {
@@ -288,19 +198,6 @@ describe('Meal Editor', () => {
           ...TEST_MEAL,
           items: TEST_MEAL.items.map((item) => (item === originalItem ? updatedItem : item)),
         });
-      });
-
-      it('restores the nutritional information when cancel is clicked', async () => {
-        const modifyButton = panel.findComponent('[data-testid="modify-button"]');
-        await modifyButton.trigger('click');
-        const mealItemEditor = panel.findComponent({ name: 'MealItemEditorCard' });
-        expect(mealItemEditor.exists()).toBe(true);
-        const cancelButton = mealItemEditor.findComponent('[data-testid="cancel-button"]');
-        await cancelButton.trigger('click');
-        expect(panel.findComponent({ name: 'MealItemEditorCard' }).exists()).toBe(false);
-        expect(panel.findComponent({ name: 'NutritionData' }).exists()).toBe(true);
-        expect(panel.findComponent('[data-testid="modify-button"]').exists()).toBe(true);
-        expect(panel.findComponent('[data-testid="delete-button"]').exists()).toBe(true);
       });
 
       it('opens the confirm dialog when delete button is clicked', async () => {

--- a/src/pages/planning/__tests__/day.spec.ts
+++ b/src/pages/planning/__tests__/day.spec.ts
@@ -167,7 +167,7 @@ describe('day', () => {
         });
       });
 
-      describe('on save', () => {
+      describe('on meal changed', () => {
         it('hides the editor', async () => {
           wrapper = await renderPage();
           const button = wrapper.findComponent('[data-testid="add-breakfast-button"]');
@@ -175,7 +175,7 @@ describe('day', () => {
           let editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-123', type: 'Breakfast', items: [] };
-          await editor.vm.$emit('save', newMeal);
+          await editor.vm.$emit('meal-changed', newMeal);
           editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(false);
         });
@@ -187,7 +187,7 @@ describe('day', () => {
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-123', type: 'Breakfast', items: [] };
-          editor.vm.$emit('save', newMeal);
+          editor.vm.$emit('meal-changed', newMeal);
           const breakfastButton = wrapper.findComponent('[data-testid="add-breakfast-button"]');
           expect(breakfastButton.exists()).toBe(false);
         });
@@ -199,7 +199,7 @@ describe('day', () => {
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-123', type: 'Breakfast', items: [] };
-          await editor.vm.$emit('save', newMeal);
+          await editor.vm.$emit('meal-changed', newMeal);
           const breakfastView = wrapper.findComponent('[data-testid="breakfast-view"]') as VueWrapper<any>;
           expect(breakfastView.exists()).toBe(true);
           expect(breakfastView.props('meal')).toEqual(newMeal);
@@ -211,7 +211,7 @@ describe('day', () => {
           await button.trigger('click');
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           const newMeal: Meal = { id: 'meal-123', type: 'Breakfast', items: [] };
-          await editor.vm.$emit('save', newMeal);
+          await editor.vm.$emit('meal-changed', newMeal);
           const breakfastView = wrapper.findComponent('[data-testid="breakfast-view"]') as VueWrapper<any>;
           await breakfastView.vm.$emit('modify');
           const modifyEditor = wrapper.findComponent({ name: 'MealEditor' });
@@ -443,7 +443,7 @@ describe('day', () => {
         });
       });
 
-      describe('on save', () => {
+      describe('on meal changed', () => {
         it('hides the editor', async () => {
           wrapper = await renderPage();
           const button = wrapper.findComponent('[data-testid="add-lunch-button"]');
@@ -451,7 +451,7 @@ describe('day', () => {
           let editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-456', type: 'Lunch', items: [] };
-          await editor.vm.$emit('save', newMeal);
+          await editor.vm.$emit('meal-changed', newMeal);
           editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(false);
         });
@@ -463,7 +463,7 @@ describe('day', () => {
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-456', type: 'Lunch', items: [] };
-          await editor.vm.$emit('save', newMeal);
+          await editor.vm.$emit('meal-changed', newMeal);
           const lunchButton = wrapper.findComponent('[data-testid="add-lunch-button"]');
           expect(lunchButton.exists()).toBe(false);
         });
@@ -475,7 +475,7 @@ describe('day', () => {
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-456', type: 'Lunch', items: [] };
-          await editor.vm.$emit('save', newMeal);
+          await editor.vm.$emit('meal-changed', newMeal);
           const lunchView = wrapper.findComponent('[data-testid="lunch-view"]') as VueWrapper<any>;
           expect(lunchView.exists()).toBe(true);
           expect(lunchView.props('meal')).toEqual(newMeal);
@@ -487,7 +487,7 @@ describe('day', () => {
           await button.trigger('click');
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           const newMeal: Meal = { id: 'meal-456', type: 'Lunch', items: [] };
-          await editor.vm.$emit('save', newMeal);
+          await editor.vm.$emit('meal-changed', newMeal);
           const lunchView = wrapper.findComponent('[data-testid="lunch-view"]') as VueWrapper<any>;
           await lunchView.vm.$emit('modify');
           const modifyEditor = wrapper.findComponent({ name: 'MealEditor' });
@@ -719,7 +719,7 @@ describe('day', () => {
         });
       });
 
-      describe('on save', () => {
+      describe('on meal changed', () => {
         it('hides the editor', async () => {
           wrapper = await renderPage();
           const button = wrapper.findComponent('[data-testid="add-dinner-button"]');
@@ -727,7 +727,7 @@ describe('day', () => {
           let editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-789', type: 'Dinner', items: [] };
-          await editor.vm.$emit('save', newMeal);
+          await editor.vm.$emit('meal-changed', newMeal);
           editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(false);
         });
@@ -739,7 +739,7 @@ describe('day', () => {
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-789', type: 'Dinner', items: [] };
-          await editor.vm.$emit('save', newMeal);
+          await editor.vm.$emit('meal-changed', newMeal);
           const dinnerButton = wrapper.findComponent('[data-testid="add-dinner-button"]');
           expect(dinnerButton.exists()).toBe(false);
         });
@@ -751,7 +751,7 @@ describe('day', () => {
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-789', type: 'Dinner', items: [] };
-          await editor.vm.$emit('save', newMeal);
+          await editor.vm.$emit('meal-changed', newMeal);
           const dinnerView = wrapper.findComponent('[data-testid="dinner-view"]') as VueWrapper<any>;
           expect(dinnerView.exists()).toBe(true);
           expect(dinnerView.props('meal')).toEqual(newMeal);
@@ -763,7 +763,7 @@ describe('day', () => {
           await button.trigger('click');
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           const newMeal: Meal = { id: 'meal-789', type: 'Dinner', items: [] };
-          await editor.vm.$emit('save', newMeal);
+          await editor.vm.$emit('meal-changed', newMeal);
           const dinnerView = wrapper.findComponent('[data-testid="dinner-view"]') as VueWrapper<any>;
           await dinnerView.vm.$emit('modify');
           const modifyEditor = wrapper.findComponent({ name: 'MealEditor' });
@@ -995,7 +995,7 @@ describe('day', () => {
         });
       });
 
-      describe('on save', () => {
+      describe('on meal changed', () => {
         it('hides the editor', async () => {
           wrapper = await renderPage();
           const button = wrapper.findComponent('[data-testid="add-snack-button"]');
@@ -1003,7 +1003,7 @@ describe('day', () => {
           let editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-snack-123', type: 'Snack', items: [] };
-          await editor.vm.$emit('save', newMeal);
+          await editor.vm.$emit('meal-changed', newMeal);
           editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(false);
         });
@@ -1015,7 +1015,7 @@ describe('day', () => {
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-snack-123', type: 'Snack', items: [] };
-          editor.vm.$emit('save', newMeal);
+          editor.vm.$emit('meal-changed', newMeal);
           const snackButton = wrapper.findComponent('[data-testid="add-snack-button"]');
           expect(snackButton.exists()).toBe(false);
         });
@@ -1027,7 +1027,7 @@ describe('day', () => {
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-snack-123', type: 'Snack', items: [] };
-          await editor.vm.$emit('save', newMeal);
+          await editor.vm.$emit('meal-changed', newMeal);
           const snackView = wrapper.findComponent('[data-testid="snack-view"]') as VueWrapper<any>;
           expect(snackView.exists()).toBe(true);
           expect(snackView.props('meal')).toEqual(newMeal);
@@ -1039,7 +1039,7 @@ describe('day', () => {
           await button.trigger('click');
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           const newMeal: Meal = { id: 'meal-snack-123', type: 'Snack', items: [] };
-          await editor.vm.$emit('save', newMeal);
+          await editor.vm.$emit('meal-changed', newMeal);
           const snackView = wrapper.findComponent('[data-testid="snack-view"]') as VueWrapper<any>;
           await snackView.vm.$emit('modify');
           const modifyEditor = wrapper.findComponent({ name: 'MealEditor' });
@@ -1209,7 +1209,7 @@ describe('day', () => {
       const editor = wrapper.findComponent({ name: 'MealEditor' });
       expect(editor.exists()).toBe(true);
       const newMeal: Meal = { id: 'meal-snack-123', type: 'Snack', items: [] };
-      await editor.vm.$emit('save', newMeal);
+      await editor.vm.$emit('meal-changed', newMeal);
     });
 
     it('exists', async () => {
@@ -1259,7 +1259,7 @@ describe('day', () => {
         await breakfastView.vm.$emit('modify');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
         const modifiedBreakfast = buildModifiedMeal(FULL_MEAL_PLAN.meals[0]!);
-        await editor.vm.$emit('save', modifiedBreakfast);
+        await editor.vm.$emit('meal-changed', modifiedBreakfast);
         const button = wrapper.findComponent('[data-testid="save-button"]');
         expect(button.attributes('disabled')).toBeUndefined();
       });
@@ -1269,7 +1269,7 @@ describe('day', () => {
         await lunchView.vm.$emit('modify');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
         const modifiedLunch = buildModifiedMeal(FULL_MEAL_PLAN.meals[1]!);
-        await editor.vm.$emit('save', modifiedLunch);
+        await editor.vm.$emit('meal-changed', modifiedLunch);
         const button = wrapper.findComponent('[data-testid="save-button"]');
         expect(button.attributes('disabled')).toBeUndefined();
       });
@@ -1279,7 +1279,7 @@ describe('day', () => {
         await dinnerView.vm.$emit('modify');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
         const modifiedDinner = buildModifiedMeal(FULL_MEAL_PLAN.meals[2]!);
-        await editor.vm.$emit('save', modifiedDinner);
+        await editor.vm.$emit('meal-changed', modifiedDinner);
         const button = wrapper.findComponent('[data-testid="save-button"]');
         expect(button.attributes('disabled')).toBeUndefined();
       });
@@ -1289,7 +1289,7 @@ describe('day', () => {
         await snackView.vm.$emit('modify');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
         const modifiedSnack = buildModifiedMeal(FULL_MEAL_PLAN.meals[3]!);
-        await editor.vm.$emit('save', modifiedSnack);
+        await editor.vm.$emit('meal-changed', modifiedSnack);
         const button = wrapper.findComponent('[data-testid="save-button"]');
         expect(button.attributes('disabled')).toBeUndefined();
       });
@@ -1343,7 +1343,7 @@ describe('day', () => {
         await breakfastView.vm.$emit('modify');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
         const modifiedBreakfast = buildModifiedMeal(FULL_MEAL_PLAN.meals[0]!);
-        await editor.vm.$emit('save', modifiedBreakfast);
+        await editor.vm.$emit('meal-changed', modifiedBreakfast);
         const button = wrapper.findComponent('[data-testid="save-button"]');
         await button.trigger('click');
         const { updateMealPlan, addMealPlan } = useMealPlansData();
@@ -1372,7 +1372,7 @@ describe('day', () => {
         const addButton = wrapper.findComponent('[data-testid="add-breakfast-button"]');
         await addButton.trigger('click');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('save', { id: 'meal-123', type: 'Breakfast', items: [] });
+        await editor.vm.$emit('meal-changed', { id: 'meal-123', type: 'Breakfast', items: [] });
         expect(button.attributes('disabled')).toBeUndefined();
       });
 
@@ -1381,7 +1381,7 @@ describe('day', () => {
         const addButton = wrapper.findComponent('[data-testid="add-lunch-button"]');
         await addButton.trigger('click');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('save', { id: 'meal-123', type: 'Lunch', items: [] });
+        await editor.vm.$emit('meal-changed', { id: 'meal-123', type: 'Lunch', items: [] });
         expect(button.attributes('disabled')).toBeUndefined();
       });
 
@@ -1390,7 +1390,7 @@ describe('day', () => {
         const addButton = wrapper.findComponent('[data-testid="add-dinner-button"]');
         await addButton.trigger('click');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('save', { id: 'meal-123', type: 'Dinner', items: [] });
+        await editor.vm.$emit('meal-changed', { id: 'meal-123', type: 'Dinner', items: [] });
         expect(button.attributes('disabled')).toBeUndefined();
       });
 
@@ -1399,7 +1399,7 @@ describe('day', () => {
         const addButton = wrapper.findComponent('[data-testid="add-snack-button"]');
         await addButton.trigger('click');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('save', { id: 'meal-123', type: 'Snack', items: [] });
+        await editor.vm.$emit('meal-changed', { id: 'meal-123', type: 'Snack', items: [] });
         expect(button.attributes('disabled')).toBeUndefined();
       });
 
@@ -1407,7 +1407,7 @@ describe('day', () => {
         const addButton = wrapper.findComponent('[data-testid="add-breakfast-button"]');
         await addButton.trigger('click');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('save', { id: 'meal-123', type: 'Breakfast', items: [] });
+        await editor.vm.$emit('meal-changed', { id: 'meal-123', type: 'Breakfast', items: [] });
         const breakfastView = wrapper.findComponent('[data-testid="breakfast-view"]') as VueWrapper<any>;
         await breakfastView.vm.$emit('delete');
         await flushPromises();
@@ -1423,11 +1423,11 @@ describe('day', () => {
         let addButton = wrapper.findComponent('[data-testid="add-breakfast-button"]');
         await addButton.trigger('click');
         let editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('save', { id: 'meal-123', type: 'Breakfast', items: [] });
+        await editor.vm.$emit('meal-changed', { id: 'meal-123', type: 'Breakfast', items: [] });
         addButton = wrapper.findComponent('[data-testid="add-dinner-button"]');
         await addButton.trigger('click');
         editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('save', { id: 'meal-456', type: 'Dinner', items: [] });
+        await editor.vm.$emit('meal-changed', { id: 'meal-456', type: 'Dinner', items: [] });
         await button.trigger('click');
         const { addMealPlan } = useMealPlansData();
         expect(addMealPlan).toHaveBeenCalledExactlyOnceWith({
@@ -1444,7 +1444,7 @@ describe('day', () => {
         const addButton = wrapper.findComponent('[data-testid="add-breakfast-button"]');
         await addButton.trigger('click');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('save', { id: 'meal-123', type: 'Breakfast', items: [] });
+        await editor.vm.$emit('meal-changed', { id: 'meal-123', type: 'Breakfast', items: [] });
         await button.trigger('click');
         expect(useRouter().replace).toHaveBeenCalledExactlyOnceWith({
           path: '/planning/week',

--- a/src/pages/planning/__tests__/day.spec.ts
+++ b/src/pages/planning/__tests__/day.spec.ts
@@ -187,7 +187,8 @@ describe('day', () => {
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-123', type: 'Breakfast', items: [] };
-          editor.vm.$emit('meal-changed', newMeal);
+          await editor.vm.$emit('meal-changed', newMeal);
+          await wrapper.vm.$nextTick();
           const breakfastButton = wrapper.findComponent('[data-testid="add-breakfast-button"]');
           expect(breakfastButton.exists()).toBe(false);
         });

--- a/src/pages/planning/__tests__/day.spec.ts
+++ b/src/pages/planning/__tests__/day.spec.ts
@@ -151,7 +151,7 @@ describe('day', () => {
           await button.trigger('click');
           let editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
-          await editor.vm.$emit('cancel');
+          await editor.vm.$emit('close');
           editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(false);
         });
@@ -161,7 +161,7 @@ describe('day', () => {
           const button = wrapper.findComponent('[data-testid="add-breakfast-button"]');
           await button.trigger('click');
           const editor = wrapper.findComponent({ name: 'MealEditor' });
-          await editor.vm.$emit('cancel');
+          await editor.vm.$emit('close');
           const breakfastButton = wrapper.findComponent('[data-testid="add-breakfast-button"]');
           expect(breakfastButton.exists()).toBe(true);
         });
@@ -200,7 +200,7 @@ describe('day', () => {
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-123', type: 'Breakfast', items: [MODIFIED_MEAL_ITEM] };
           await editor.vm.$emit('meal-changed', newMeal);
-          await editor.vm.$emit('cancel');
+          await editor.vm.$emit('close');
           const breakfastView = wrapper.findComponent('[data-testid="breakfast-view"]') as VueWrapper<any>;
           expect(breakfastView.exists()).toBe(true);
           expect(breakfastView.props('meal')).toEqual(newMeal);
@@ -213,7 +213,7 @@ describe('day', () => {
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           const newMeal: Meal = { id: 'meal-123', type: 'Breakfast', items: [MODIFIED_MEAL_ITEM] };
           await editor.vm.$emit('meal-changed', newMeal);
-          await editor.vm.$emit('cancel');
+          await editor.vm.$emit('close');
           const breakfastView = wrapper.findComponent('[data-testid="breakfast-view"]') as VueWrapper<any>;
           await breakfastView.vm.$emit('modify');
           const modifyEditor = wrapper.findComponent({ name: 'MealEditor' });
@@ -278,7 +278,7 @@ describe('day', () => {
         const breakfastView = wrapper.findComponent('[data-testid="breakfast-view"]') as VueWrapper<any>;
         await breakfastView.vm.$emit('modify');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('cancel');
+        await editor.vm.$emit('close');
         expect(wrapper.findComponent({ name: 'MealEditor' }).exists()).toBe(false);
       });
 
@@ -289,7 +289,7 @@ describe('day', () => {
         const breakfastView = wrapper.findComponent('[data-testid="breakfast-view"]') as VueWrapper<any>;
         await breakfastView.vm.$emit('modify');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('cancel');
+        await editor.vm.$emit('close');
         expect(wrapper.findComponent('[data-testid="breakfast-view"]').exists()).toBe(true);
       });
 
@@ -300,7 +300,7 @@ describe('day', () => {
         const breakfastView = wrapper.findComponent('[data-testid="breakfast-view"]') as VueWrapper<any>;
         await breakfastView.vm.$emit('modify');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('cancel');
+        await editor.vm.$emit('close');
         expect(wrapper.findComponent('[data-testid="add-breakfast-button"]').exists()).toBe(false);
       });
     });
@@ -429,7 +429,7 @@ describe('day', () => {
           await button.trigger('click');
           let editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
-          await editor.vm.$emit('cancel');
+          await editor.vm.$emit('close');
           editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(false);
         });
@@ -439,7 +439,7 @@ describe('day', () => {
           const button = wrapper.findComponent('[data-testid="add-lunch-button"]');
           await button.trigger('click');
           const editor = wrapper.findComponent({ name: 'MealEditor' });
-          await editor.vm.$emit('cancel');
+          await editor.vm.$emit('close');
           const lunchButton = wrapper.findComponent('[data-testid="add-lunch-button"]');
           expect(lunchButton.exists()).toBe(true);
         });
@@ -477,7 +477,7 @@ describe('day', () => {
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-456', type: 'Lunch', items: [MODIFIED_MEAL_ITEM] };
           await editor.vm.$emit('meal-changed', newMeal);
-          await editor.vm.$emit('cancel');
+          await editor.vm.$emit('close');
           const lunchView = wrapper.findComponent('[data-testid="lunch-view"]') as VueWrapper<any>;
           expect(lunchView.exists()).toBe(true);
           expect(lunchView.props('meal')).toEqual(newMeal);
@@ -490,7 +490,7 @@ describe('day', () => {
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           const newMeal: Meal = { id: 'meal-456', type: 'Lunch', items: [MODIFIED_MEAL_ITEM] };
           await editor.vm.$emit('meal-changed', newMeal);
-          await editor.vm.$emit('cancel');
+          await editor.vm.$emit('close');
           const lunchView = wrapper.findComponent('[data-testid="lunch-view"]') as VueWrapper<any>;
           await lunchView.vm.$emit('modify');
           const modifyEditor = wrapper.findComponent({ name: 'MealEditor' });
@@ -555,7 +555,7 @@ describe('day', () => {
         const lunchView = wrapper.findComponent('[data-testid="lunch-view"]') as VueWrapper<any>;
         await lunchView.vm.$emit('modify');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('cancel');
+        await editor.vm.$emit('close');
         expect(wrapper.findComponent({ name: 'MealEditor' }).exists()).toBe(false);
       });
 
@@ -566,7 +566,7 @@ describe('day', () => {
         const lunchView = wrapper.findComponent('[data-testid="lunch-view"]') as VueWrapper<any>;
         await lunchView.vm.$emit('modify');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('cancel');
+        await editor.vm.$emit('close');
         expect(wrapper.findComponent('[data-testid="lunch-view"]').exists()).toBe(true);
       });
 
@@ -577,7 +577,7 @@ describe('day', () => {
         const lunchView = wrapper.findComponent('[data-testid="lunch-view"]') as VueWrapper<any>;
         await lunchView.vm.$emit('modify');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('cancel');
+        await editor.vm.$emit('close');
         expect(wrapper.findComponent('[data-testid="add-lunch-button"]').exists()).toBe(false);
       });
     });
@@ -706,7 +706,7 @@ describe('day', () => {
           await button.trigger('click');
           let editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
-          await editor.vm.$emit('cancel');
+          await editor.vm.$emit('close');
           editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(false);
         });
@@ -716,7 +716,7 @@ describe('day', () => {
           const button = wrapper.findComponent('[data-testid="add-dinner-button"]');
           await button.trigger('click');
           const editor = wrapper.findComponent({ name: 'MealEditor' });
-          await editor.vm.$emit('cancel');
+          await editor.vm.$emit('close');
           const dinnerButton = wrapper.findComponent('[data-testid="add-dinner-button"]');
           expect(dinnerButton.exists()).toBe(true);
         });
@@ -754,7 +754,7 @@ describe('day', () => {
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-789', type: 'Dinner', items: [MODIFIED_MEAL_ITEM] };
           await editor.vm.$emit('meal-changed', newMeal);
-          await editor.vm.$emit('cancel');
+          await editor.vm.$emit('close');
           const dinnerView = wrapper.findComponent('[data-testid="dinner-view"]') as VueWrapper<any>;
           expect(dinnerView.exists()).toBe(true);
           expect(dinnerView.props('meal')).toEqual(newMeal);
@@ -767,7 +767,7 @@ describe('day', () => {
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           const newMeal: Meal = { id: 'meal-789', type: 'Dinner', items: [MODIFIED_MEAL_ITEM] };
           await editor.vm.$emit('meal-changed', newMeal);
-          await editor.vm.$emit('cancel');
+          await editor.vm.$emit('close');
           const dinnerView = wrapper.findComponent('[data-testid="dinner-view"]') as VueWrapper<any>;
           await dinnerView.vm.$emit('modify');
           const modifyEditor = wrapper.findComponent({ name: 'MealEditor' });
@@ -832,7 +832,7 @@ describe('day', () => {
         const dinnerView = wrapper.findComponent('[data-testid="dinner-view"]') as VueWrapper<any>;
         await dinnerView.vm.$emit('modify');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('cancel');
+        await editor.vm.$emit('close');
         expect(wrapper.findComponent({ name: 'MealEditor' }).exists()).toBe(false);
       });
 
@@ -843,7 +843,7 @@ describe('day', () => {
         const dinnerView = wrapper.findComponent('[data-testid="dinner-view"]') as VueWrapper<any>;
         await dinnerView.vm.$emit('modify');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('cancel');
+        await editor.vm.$emit('close');
         expect(wrapper.findComponent('[data-testid="dinner-view"]').exists()).toBe(true);
       });
 
@@ -854,7 +854,7 @@ describe('day', () => {
         const dinnerView = wrapper.findComponent('[data-testid="dinner-view"]') as VueWrapper<any>;
         await dinnerView.vm.$emit('modify');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('cancel');
+        await editor.vm.$emit('close');
         expect(wrapper.findComponent('[data-testid="add-dinner-button"]').exists()).toBe(false);
       });
     });
@@ -983,7 +983,7 @@ describe('day', () => {
           await button.trigger('click');
           let editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
-          await editor.vm.$emit('cancel');
+          await editor.vm.$emit('close');
           editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(false);
         });
@@ -993,7 +993,7 @@ describe('day', () => {
           const button = wrapper.findComponent('[data-testid="add-snack-button"]');
           await button.trigger('click');
           const editor = wrapper.findComponent({ name: 'MealEditor' });
-          await editor.vm.$emit('cancel');
+          await editor.vm.$emit('close');
           const snackButton = wrapper.findComponent('[data-testid="add-snack-button"]');
           expect(snackButton.exists()).toBe(true);
         });
@@ -1032,7 +1032,7 @@ describe('day', () => {
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-snack-123', type: 'Snack', items: [MODIFIED_MEAL_ITEM] };
           await editor.vm.$emit('meal-changed', newMeal);
-          await editor.vm.$emit('cancel');
+          await editor.vm.$emit('close');
           const snackView = wrapper.findComponent('[data-testid="snack-view"]') as VueWrapper<any>;
           expect(snackView.exists()).toBe(true);
           expect(snackView.props('meal')).toEqual(newMeal);
@@ -1045,7 +1045,7 @@ describe('day', () => {
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           const newMeal: Meal = { id: 'meal-snack-123', type: 'Snack', items: [MODIFIED_MEAL_ITEM] };
           await editor.vm.$emit('meal-changed', newMeal);
-          await editor.vm.$emit('cancel');
+          await editor.vm.$emit('close');
           const snackView = wrapper.findComponent('[data-testid="snack-view"]') as VueWrapper<any>;
           await snackView.vm.$emit('modify');
           const modifyEditor = wrapper.findComponent({ name: 'MealEditor' });
@@ -1110,7 +1110,7 @@ describe('day', () => {
         const snackView = wrapper.findComponent('[data-testid="snack-view"]') as VueWrapper<any>;
         await snackView.vm.$emit('modify');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('cancel');
+        await editor.vm.$emit('close');
         expect(wrapper.findComponent({ name: 'MealEditor' }).exists()).toBe(false);
       });
 
@@ -1121,7 +1121,7 @@ describe('day', () => {
         const snackView = wrapper.findComponent('[data-testid="snack-view"]') as VueWrapper<any>;
         await snackView.vm.$emit('modify');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('cancel');
+        await editor.vm.$emit('close');
         expect(wrapper.findComponent('[data-testid="snack-view"]').exists()).toBe(true);
       });
 
@@ -1132,7 +1132,7 @@ describe('day', () => {
         const snackView = wrapper.findComponent('[data-testid="snack-view"]') as VueWrapper<any>;
         await snackView.vm.$emit('modify');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('cancel');
+        await editor.vm.$emit('close');
         expect(wrapper.findComponent('[data-testid="add-snack-button"]').exists()).toBe(false);
       });
     });
@@ -1414,7 +1414,7 @@ describe('day', () => {
         await addButton.trigger('click');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
         await editor.vm.$emit('meal-changed', { id: 'meal-123', type: 'Breakfast', items: [MODIFIED_MEAL_ITEM] });
-        await editor.vm.$emit('cancel');
+        await editor.vm.$emit('close');
         const breakfastView = wrapper.findComponent('[data-testid="breakfast-view"]') as VueWrapper<any>;
         await breakfastView.vm.$emit('delete');
         await flushPromises();
@@ -1433,7 +1433,7 @@ describe('day', () => {
         await addButton.trigger('click');
         let editor = wrapper.findComponent({ name: 'MealEditor' });
         await editor.vm.$emit('meal-changed', breakfastMeal);
-        await editor.vm.$emit('cancel');
+        await editor.vm.$emit('close');
         addButton = wrapper.findComponent('[data-testid="add-dinner-button"]');
         await addButton.trigger('click');
         editor = wrapper.findComponent({ name: 'MealEditor' });

--- a/src/pages/planning/__tests__/day.spec.ts
+++ b/src/pages/planning/__tests__/day.spec.ts
@@ -1016,7 +1016,8 @@ describe('day', () => {
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-snack-123', type: 'Snack', items: [] };
-          editor.vm.$emit('meal-changed', newMeal);
+          await editor.vm.$emit('meal-changed', newMeal);
+          await wrapper.vm.$nextTick();
           const snackButton = wrapper.findComponent('[data-testid="add-snack-button"]');
           expect(snackButton.exists()).toBe(false);
         });

--- a/src/pages/planning/__tests__/day.spec.ts
+++ b/src/pages/planning/__tests__/day.spec.ts
@@ -168,16 +168,15 @@ describe('day', () => {
       });
 
       describe('on meal changed', () => {
-        it('hides the editor', async () => {
+        it('keeps the editor open', async () => {
           wrapper = await renderPage();
           const button = wrapper.findComponent('[data-testid="add-breakfast-button"]');
           await button.trigger('click');
-          let editor = wrapper.findComponent({ name: 'MealEditor' });
+          const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-123', type: 'Breakfast', items: [] };
           await editor.vm.$emit('meal-changed', newMeal);
-          editor = wrapper.findComponent({ name: 'MealEditor' });
-          expect(editor.exists()).toBe(false);
+          expect(wrapper.findComponent({ name: 'MealEditor' }).exists()).toBe(true);
         });
 
         it('does not show the add breakfast button again', async () => {
@@ -193,14 +192,15 @@ describe('day', () => {
           expect(breakfastButton.exists()).toBe(false);
         });
 
-        it('assigns the meal to the breakfast view', async () => {
+        it('assigns the meal to the breakfast view after the editor is closed', async () => {
           wrapper = await renderPage();
           const button = wrapper.findComponent('[data-testid="add-breakfast-button"]');
           await button.trigger('click');
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
-          const newMeal: Meal = { id: 'meal-123', type: 'Breakfast', items: [] };
+          const newMeal: Meal = { id: 'meal-123', type: 'Breakfast', items: [MODIFIED_MEAL_ITEM] };
           await editor.vm.$emit('meal-changed', newMeal);
+          await editor.vm.$emit('cancel');
           const breakfastView = wrapper.findComponent('[data-testid="breakfast-view"]') as VueWrapper<any>;
           expect(breakfastView.exists()).toBe(true);
           expect(breakfastView.props('meal')).toEqual(newMeal);
@@ -211,8 +211,9 @@ describe('day', () => {
           const button = wrapper.findComponent('[data-testid="add-breakfast-button"]');
           await button.trigger('click');
           const editor = wrapper.findComponent({ name: 'MealEditor' });
-          const newMeal: Meal = { id: 'meal-123', type: 'Breakfast', items: [] };
+          const newMeal: Meal = { id: 'meal-123', type: 'Breakfast', items: [MODIFIED_MEAL_ITEM] };
           await editor.vm.$emit('meal-changed', newMeal);
+          await editor.vm.$emit('cancel');
           const breakfastView = wrapper.findComponent('[data-testid="breakfast-view"]') as VueWrapper<any>;
           await breakfastView.vm.$emit('modify');
           const modifyEditor = wrapper.findComponent({ name: 'MealEditor' });
@@ -445,16 +446,15 @@ describe('day', () => {
       });
 
       describe('on meal changed', () => {
-        it('hides the editor', async () => {
+        it('keeps the editor open', async () => {
           wrapper = await renderPage();
           const button = wrapper.findComponent('[data-testid="add-lunch-button"]');
           await button.trigger('click');
-          let editor = wrapper.findComponent({ name: 'MealEditor' });
+          const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-456', type: 'Lunch', items: [] };
           await editor.vm.$emit('meal-changed', newMeal);
-          editor = wrapper.findComponent({ name: 'MealEditor' });
-          expect(editor.exists()).toBe(false);
+          expect(wrapper.findComponent({ name: 'MealEditor' }).exists()).toBe(true);
         });
 
         it('does not show the add lunch button again', async () => {
@@ -469,14 +469,15 @@ describe('day', () => {
           expect(lunchButton.exists()).toBe(false);
         });
 
-        it('assigns the meal to the lunch view', async () => {
+        it('assigns the meal to the lunch view after the editor is closed', async () => {
           wrapper = await renderPage();
           const button = wrapper.findComponent('[data-testid="add-lunch-button"]');
           await button.trigger('click');
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
-          const newMeal: Meal = { id: 'meal-456', type: 'Lunch', items: [] };
+          const newMeal: Meal = { id: 'meal-456', type: 'Lunch', items: [MODIFIED_MEAL_ITEM] };
           await editor.vm.$emit('meal-changed', newMeal);
+          await editor.vm.$emit('cancel');
           const lunchView = wrapper.findComponent('[data-testid="lunch-view"]') as VueWrapper<any>;
           expect(lunchView.exists()).toBe(true);
           expect(lunchView.props('meal')).toEqual(newMeal);
@@ -487,8 +488,9 @@ describe('day', () => {
           const button = wrapper.findComponent('[data-testid="add-lunch-button"]');
           await button.trigger('click');
           const editor = wrapper.findComponent({ name: 'MealEditor' });
-          const newMeal: Meal = { id: 'meal-456', type: 'Lunch', items: [] };
+          const newMeal: Meal = { id: 'meal-456', type: 'Lunch', items: [MODIFIED_MEAL_ITEM] };
           await editor.vm.$emit('meal-changed', newMeal);
+          await editor.vm.$emit('cancel');
           const lunchView = wrapper.findComponent('[data-testid="lunch-view"]') as VueWrapper<any>;
           await lunchView.vm.$emit('modify');
           const modifyEditor = wrapper.findComponent({ name: 'MealEditor' });
@@ -721,16 +723,15 @@ describe('day', () => {
       });
 
       describe('on meal changed', () => {
-        it('hides the editor', async () => {
+        it('keeps the editor open', async () => {
           wrapper = await renderPage();
           const button = wrapper.findComponent('[data-testid="add-dinner-button"]');
           await button.trigger('click');
-          let editor = wrapper.findComponent({ name: 'MealEditor' });
+          const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-789', type: 'Dinner', items: [] };
           await editor.vm.$emit('meal-changed', newMeal);
-          editor = wrapper.findComponent({ name: 'MealEditor' });
-          expect(editor.exists()).toBe(false);
+          expect(wrapper.findComponent({ name: 'MealEditor' }).exists()).toBe(true);
         });
 
         it('does not show the add dinner button again', async () => {
@@ -745,14 +746,15 @@ describe('day', () => {
           expect(dinnerButton.exists()).toBe(false);
         });
 
-        it('assigns the meal to the dinner view', async () => {
+        it('assigns the meal to the dinner view after the editor is closed', async () => {
           wrapper = await renderPage();
           const button = wrapper.findComponent('[data-testid="add-dinner-button"]');
           await button.trigger('click');
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
-          const newMeal: Meal = { id: 'meal-789', type: 'Dinner', items: [] };
+          const newMeal: Meal = { id: 'meal-789', type: 'Dinner', items: [MODIFIED_MEAL_ITEM] };
           await editor.vm.$emit('meal-changed', newMeal);
+          await editor.vm.$emit('cancel');
           const dinnerView = wrapper.findComponent('[data-testid="dinner-view"]') as VueWrapper<any>;
           expect(dinnerView.exists()).toBe(true);
           expect(dinnerView.props('meal')).toEqual(newMeal);
@@ -763,8 +765,9 @@ describe('day', () => {
           const button = wrapper.findComponent('[data-testid="add-dinner-button"]');
           await button.trigger('click');
           const editor = wrapper.findComponent({ name: 'MealEditor' });
-          const newMeal: Meal = { id: 'meal-789', type: 'Dinner', items: [] };
+          const newMeal: Meal = { id: 'meal-789', type: 'Dinner', items: [MODIFIED_MEAL_ITEM] };
           await editor.vm.$emit('meal-changed', newMeal);
+          await editor.vm.$emit('cancel');
           const dinnerView = wrapper.findComponent('[data-testid="dinner-view"]') as VueWrapper<any>;
           await dinnerView.vm.$emit('modify');
           const modifyEditor = wrapper.findComponent({ name: 'MealEditor' });
@@ -997,16 +1000,15 @@ describe('day', () => {
       });
 
       describe('on meal changed', () => {
-        it('hides the editor', async () => {
+        it('keeps the editor open', async () => {
           wrapper = await renderPage();
           const button = wrapper.findComponent('[data-testid="add-snack-button"]');
           await button.trigger('click');
-          let editor = wrapper.findComponent({ name: 'MealEditor' });
+          const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
           const newMeal: Meal = { id: 'meal-snack-123', type: 'Snack', items: [] };
           await editor.vm.$emit('meal-changed', newMeal);
-          editor = wrapper.findComponent({ name: 'MealEditor' });
-          expect(editor.exists()).toBe(false);
+          expect(wrapper.findComponent({ name: 'MealEditor' }).exists()).toBe(true);
         });
 
         it('does not show the add snack button again', async () => {
@@ -1022,14 +1024,15 @@ describe('day', () => {
           expect(snackButton.exists()).toBe(false);
         });
 
-        it('assigns the meal to the snack view', async () => {
+        it('assigns the meal to the snack view after the editor is closed', async () => {
           wrapper = await renderPage();
           const button = wrapper.findComponent('[data-testid="add-snack-button"]');
           await button.trigger('click');
           const editor = wrapper.findComponent({ name: 'MealEditor' });
           expect(editor.exists()).toBe(true);
-          const newMeal: Meal = { id: 'meal-snack-123', type: 'Snack', items: [] };
+          const newMeal: Meal = { id: 'meal-snack-123', type: 'Snack', items: [MODIFIED_MEAL_ITEM] };
           await editor.vm.$emit('meal-changed', newMeal);
+          await editor.vm.$emit('cancel');
           const snackView = wrapper.findComponent('[data-testid="snack-view"]') as VueWrapper<any>;
           expect(snackView.exists()).toBe(true);
           expect(snackView.props('meal')).toEqual(newMeal);
@@ -1040,8 +1043,9 @@ describe('day', () => {
           const button = wrapper.findComponent('[data-testid="add-snack-button"]');
           await button.trigger('click');
           const editor = wrapper.findComponent({ name: 'MealEditor' });
-          const newMeal: Meal = { id: 'meal-snack-123', type: 'Snack', items: [] };
+          const newMeal: Meal = { id: 'meal-snack-123', type: 'Snack', items: [MODIFIED_MEAL_ITEM] };
           await editor.vm.$emit('meal-changed', newMeal);
+          await editor.vm.$emit('cancel');
           const snackView = wrapper.findComponent('[data-testid="snack-view"]') as VueWrapper<any>;
           await snackView.vm.$emit('modify');
           const modifyEditor = wrapper.findComponent({ name: 'MealEditor' });
@@ -1409,7 +1413,8 @@ describe('day', () => {
         const addButton = wrapper.findComponent('[data-testid="add-breakfast-button"]');
         await addButton.trigger('click');
         const editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('meal-changed', { id: 'meal-123', type: 'Breakfast', items: [] });
+        await editor.vm.$emit('meal-changed', { id: 'meal-123', type: 'Breakfast', items: [MODIFIED_MEAL_ITEM] });
+        await editor.vm.$emit('cancel');
         const breakfastView = wrapper.findComponent('[data-testid="breakfast-view"]') as VueWrapper<any>;
         await breakfastView.vm.$emit('delete');
         await flushPromises();
@@ -1422,22 +1427,22 @@ describe('day', () => {
 
       it('saves the meal plan', async () => {
         const button = wrapper.findComponent('[data-testid="save-button"]');
+        const breakfastMeal = { id: 'meal-123', type: 'Breakfast', items: [MODIFIED_MEAL_ITEM] };
+        const dinnerMeal = { id: 'meal-456', type: 'Dinner', items: [MODIFIED_MEAL_ITEM] };
         let addButton = wrapper.findComponent('[data-testid="add-breakfast-button"]');
         await addButton.trigger('click');
         let editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('meal-changed', { id: 'meal-123', type: 'Breakfast', items: [] });
+        await editor.vm.$emit('meal-changed', breakfastMeal);
+        await editor.vm.$emit('cancel');
         addButton = wrapper.findComponent('[data-testid="add-dinner-button"]');
         await addButton.trigger('click');
         editor = wrapper.findComponent({ name: 'MealEditor' });
-        await editor.vm.$emit('meal-changed', { id: 'meal-456', type: 'Dinner', items: [] });
+        await editor.vm.$emit('meal-changed', dinnerMeal);
         await button.trigger('click');
         const { addMealPlan } = useMealPlansData();
         expect(addMealPlan).toHaveBeenCalledExactlyOnceWith({
           date: '2026-02-18',
-          meals: [
-            { id: 'meal-123', type: 'Breakfast', items: [] },
-            { id: 'meal-456', type: 'Dinner', items: [] },
-          ],
+          meals: [breakfastMeal, dinnerMeal],
         });
       });
 

--- a/src/pages/planning/day.vue
+++ b/src/pages/planning/day.vue
@@ -24,7 +24,7 @@
       v-if="breakfast.isEditing"
       :meal="breakfast.item!"
       @meal-changed="(meal) => updateMeal('Breakfast', meal)"
-      @cancel="cancelMeal('Breakfast')"
+      @close="cancelMeal('Breakfast')"
     />
   </div>
   <div class="d-flex justify-space-between align-center">
@@ -51,7 +51,7 @@
       v-if="lunch.isEditing"
       :meal="lunch.item!"
       @meal-changed="(meal) => updateMeal('Lunch', meal)"
-      @cancel="cancelMeal('Lunch')"
+      @close="cancelMeal('Lunch')"
     />
   </div>
   <div class="d-flex justify-space-between align-center">
@@ -78,7 +78,7 @@
       v-if="dinner.isEditing"
       :meal="dinner.item!"
       @meal-changed="(meal) => updateMeal('Dinner', meal)"
-      @cancel="cancelMeal('Dinner')"
+      @close="cancelMeal('Dinner')"
     />
   </div>
   <div class="d-flex justify-space-between align-center">
@@ -105,7 +105,7 @@
       v-if="snack.isEditing"
       :meal="snack.item!"
       @meal-changed="(meal) => updateMeal('Snack', meal)"
-      @cancel="cancelMeal('Snack')"
+      @close="cancelMeal('Snack')"
     />
   </div>
   <div class="d-flex justify-end mt-4">

--- a/src/pages/planning/day.vue
+++ b/src/pages/planning/day.vue
@@ -23,7 +23,7 @@
     <MealEditor
       v-if="breakfast.isEditing"
       :meal="breakfast.item!"
-      @save="(meal) => setMeal('Breakfast', meal)"
+      @meal-changed="(meal) => setMeal('Breakfast', meal)"
       @cancel="cancelMeal('Breakfast')"
     />
   </div>
@@ -50,7 +50,7 @@
     <MealEditor
       v-if="lunch.isEditing"
       :meal="lunch.item!"
-      @save="(meal) => setMeal('Lunch', meal)"
+      @meal-changed="(meal) => setMeal('Lunch', meal)"
       @cancel="cancelMeal('Lunch')"
     />
   </div>
@@ -77,7 +77,7 @@
     <MealEditor
       v-if="dinner.isEditing"
       :meal="dinner.item!"
-      @save="(meal) => setMeal('Dinner', meal)"
+      @meal-changed="(meal) => setMeal('Dinner', meal)"
       @cancel="cancelMeal('Dinner')"
     />
   </div>
@@ -104,7 +104,7 @@
     <MealEditor
       v-if="snack.isEditing"
       :meal="snack.item!"
-      @save="(meal) => setMeal('Snack', meal)"
+      @meal-changed="(meal) => setMeal('Snack', meal)"
       @cancel="cancelMeal('Snack')"
     />
   </div>

--- a/src/pages/planning/day.vue
+++ b/src/pages/planning/day.vue
@@ -23,7 +23,7 @@
     <MealEditor
       v-if="breakfast.isEditing"
       :meal="breakfast.item!"
-      @meal-changed="(meal) => setMeal('Breakfast', meal)"
+      @meal-changed="(meal) => updateMeal('Breakfast', meal)"
       @cancel="cancelMeal('Breakfast')"
     />
   </div>
@@ -50,7 +50,7 @@
     <MealEditor
       v-if="lunch.isEditing"
       :meal="lunch.item!"
-      @meal-changed="(meal) => setMeal('Lunch', meal)"
+      @meal-changed="(meal) => updateMeal('Lunch', meal)"
       @cancel="cancelMeal('Lunch')"
     />
   </div>
@@ -77,7 +77,7 @@
     <MealEditor
       v-if="dinner.isEditing"
       :meal="dinner.item!"
-      @meal-changed="(meal) => setMeal('Dinner', meal)"
+      @meal-changed="(meal) => updateMeal('Dinner', meal)"
       @cancel="cancelMeal('Dinner')"
     />
   </div>
@@ -104,7 +104,7 @@
     <MealEditor
       v-if="snack.isEditing"
       :meal="snack.item!"
-      @meal-changed="(meal) => setMeal('Snack', meal)"
+      @meal-changed="(meal) => updateMeal('Snack', meal)"
       @cancel="cancelMeal('Snack')"
     />
   </div>
@@ -205,12 +205,11 @@ const mealRefs: Record<string, typeof breakfast> = {
   Snack: snack,
 };
 
-const setMeal = (mealType: MealType, meal: Meal | undefined) => {
+const updateMeal = (mealType: MealType, meal: Meal) => {
   const mealRef = mealRefs[mealType];
   if (mealRef && mealRef.value) {
     mealRef.value.item = meal;
     isDirty.value = true;
-    mealRef.value.isEditing = false;
   }
 };
 


### PR DESCRIPTION
`MealEditor` previously required a Save/Cancel cycle for the parent to observe changes. This PR replaces that with immediate `meal-changed` emissions on every item add/update/delete, and a `close` event when the editor is dismissed.

## MealEditor changes
- Added `meal-changed` event emitted on `createMealItem`, `updateMealItem`, and `removeMealItem`
- Extracted `currentMeal()` helper to build the meal snapshot consistently across all three emit sites
- Replaced Save/Cancel buttons with a single Close button
- Renamed emitted event `cancel` → `close` (cancel no longer implies "discard"; changes are already applied)

## day.vue changes
- `@meal-changed` → `updateMeal()`: updates `meal.item` + sets `isDirty`, **without** closing the editor — keeps multi-step edits (e.g. adding several recipes) in a single session
- `@close` → `cancelMeal()`: closes the editor; clears the meal ref if no items were added

```ts
// Before: every change closed the editor
const setMeal = (mealType: MealType, meal: Meal | undefined) => {
  mealRef.value.item = meal;
  isDirty.value = true;
  mealRef.value.isEditing = false; // ← premature close
};

// After: close only on explicit dismiss
const updateMeal = (mealType: MealType, meal: Meal) => {
  mealRef.value.item = meal;
  isDirty.value = true;
};
```