### PR TITLE
Guard against null settings before building weekly data

### DIFF
--- a/src/core/__tests__/build-data-for-week.spec.ts
+++ b/src/core/__tests__/build-data-for-week.spec.ts
@@ -12,24 +12,22 @@ const makeSettings = (weekStartDay: 0 | 1 = 0): Settings => ({
   weekStartDay,
 });
 
-const makeMealPlan = (id: string, calories: number, protein: number, carbs: number): MealPlan => ({
+type ItemNutrition = { calories: number; protein: number; carbs: number };
+
+const makeMealPlan = (id: string, meals: ItemNutrition[][]): MealPlan => ({
   id,
   date: '2025-12-25',
-  meals: [
-    {
-      id: `meal-${id}`,
-      type: 'Lunch',
-      items: [
-        {
-          id: `item-${id}`,
-          name: 'Test Food',
-          recipeId: 'test-recipe',
-          servings: 1,
-          nutrition: { calories, protein, carbs, fat: 0, sugar: 0, sodium: 0 },
-        },
-      ],
-    },
-  ],
+  meals: meals.map((items, mealIndex) => ({
+    id: `meal-${id}-${mealIndex}`,
+    type: 'Lunch',
+    items: items.map((nutrition, itemIndex) => ({
+      id: `item-${id}-${mealIndex}-${itemIndex}`,
+      name: 'Test Food',
+      recipeId: 'test-recipe',
+      servings: 1,
+      nutrition: { ...nutrition, fat: 0, sugar: 0, sodium: 0 },
+    })),
+  })),
 });
 
 // Dec 25, 2025 is a Thursday
@@ -72,9 +70,9 @@ describe('buildDataForWeek', () => {
 
   it('returns the number of days that have meals', async () => {
     const mealPlans = [
-      makeMealPlan('mp-1', 500, 30, 60),
-      makeMealPlan('mp-2', 600, 40, 70),
-      { ...makeMealPlan('mp-3', 0, 0, 0), meals: [] },
+      makeMealPlan('mp-1', [[{ calories: 500, protein: 30, carbs: 60 }]]),
+      makeMealPlan('mp-2', [[{ calories: 600, protein: 40, carbs: 70 }]]),
+      makeMealPlan('mp-3', []),
     ];
     const getMealPlansForPeriod = vi.fn().mockResolvedValue(mealPlans);
     const result = await buildDataForWeek(START_DATE, makeSettings(), getMealPlansForPeriod);
@@ -82,20 +80,29 @@ describe('buildDataForWeek', () => {
   });
 
   it('calculates average calories, protein, and carbs over days with meals', async () => {
-    const mealPlans = [makeMealPlan('mp-1', 500, 31, 62), makeMealPlan('mp-2', 601, 41, 71)];
+    const mealPlans = [
+      makeMealPlan('mp-1', [[{ calories: 300, protein: 20, carbs: 40 }], [{ calories: 200, protein: 11, carbs: 22 }]]),
+      makeMealPlan('mp-2', [
+        [
+          { calories: 400, protein: 25, carbs: 35 },
+          { calories: 201, protein: 16, carbs: 36 },
+        ],
+      ]),
+    ];
     const getMealPlansForPeriod = vi.fn().mockResolvedValue(mealPlans);
     const result = await buildDataForWeek(START_DATE, makeSettings(), getMealPlansForPeriod);
+    // mp-1: 500 cal / 31 protein / 62 carbs; mp-2: 601 cal / 41 protein / 71 carbs
     expect(result.averageCalories).toBe(Math.round((500 + 601) / 2));
     expect(result.averageProtein).toBe(Math.round((31 + 41) / 2));
     expect(result.averageCarbs).toBe(Math.round((62 + 71) / 2));
   });
 
   it('rounds averages to the nearest integer', async () => {
-    // 3 items summing to values that produce non-integer averages
+    // 3 days summing to values that produce non-integer averages
     const mealPlans = [
-      makeMealPlan('mp-1', 100, 10, 20),
-      makeMealPlan('mp-2', 200, 20, 30),
-      makeMealPlan('mp-3', 300, 30, 40),
+      makeMealPlan('mp-1', [[{ calories: 100, protein: 10, carbs: 20 }]]),
+      makeMealPlan('mp-2', [[{ calories: 200, protein: 20, carbs: 30 }]]),
+      makeMealPlan('mp-3', [[{ calories: 300, protein: 30, carbs: 40 }]]),
     ];
     const getMealPlansForPeriod = vi.fn().mockResolvedValue(mealPlans);
     const result = await buildDataForWeek(START_DATE, makeSettings(), getMealPlansForPeriod);

--- a/src/core/__tests__/build-data-for-week.spec.ts
+++ b/src/core/__tests__/build-data-for-week.spec.ts
@@ -1,0 +1,114 @@
+import type { MealPlan } from '@/models/meal-plan';
+import type { Settings } from '@/models/settings';
+import { describe, expect, it, vi } from 'vitest';
+import { buildDataForWeek } from '../build-data-for-week';
+
+const makeSettings = (weekStartDay: 0 | 1 = 0): Settings => ({
+  dailyCalorieLimit: 2000,
+  dailySugarLimit: 50,
+  dailyProteinTarget: 150,
+  tolerance: 10,
+  cheatDays: 1,
+  weekStartDay,
+});
+
+const makeMealPlan = (id: string, calories: number, protein: number, carbs: number): MealPlan => ({
+  id,
+  date: '2025-12-25',
+  meals: [
+    {
+      id: `meal-${id}`,
+      type: 'Lunch',
+      items: [
+        {
+          id: `item-${id}`,
+          name: 'Test Food',
+          recipeId: 'test-recipe',
+          servings: 1,
+          nutrition: { calories, protein, carbs, fat: 0, sugar: 0, sodium: 0 },
+        },
+      ],
+    },
+  ],
+});
+
+// Dec 25, 2025 is a Thursday
+const START_DATE = new Date(2025, 11, 25);
+
+describe('buildDataForWeek', () => {
+  it('calls getMealPlansForPeriod with ISO-formatted start and end dates', async () => {
+    const getMealPlansForPeriod = vi.fn().mockResolvedValue([]);
+    await buildDataForWeek(START_DATE, makeSettings(0), getMealPlansForPeriod);
+    // weekStartsOn=0 (Sunday): week is Dec 21–27, so end date is Dec 27
+    expect(getMealPlansForPeriod).toHaveBeenCalledWith('2025-12-25', '2025-12-27');
+  });
+
+  it('returns the provided startDate', async () => {
+    const getMealPlansForPeriod = vi.fn().mockResolvedValue([]);
+    const result = await buildDataForWeek(START_DATE, makeSettings(), getMealPlansForPeriod);
+    expect(result.startDate).toBe(START_DATE);
+  });
+
+  it('returns an endDate based on the weekStartDay setting', async () => {
+    const getMealPlansForPeriod = vi.fn().mockResolvedValue([]);
+
+    // weekStartsOn=0 (Sunday): week ends Saturday Dec 27
+    const sundayStart = await buildDataForWeek(START_DATE, makeSettings(0), getMealPlansForPeriod);
+    expect(sundayStart.endDate.getFullYear()).toBe(2025);
+    expect(sundayStart.endDate.getMonth()).toBe(11);
+    expect(sundayStart.endDate.getDate()).toBe(27);
+
+    // weekStartsOn=1 (Monday): week ends Sunday Dec 28
+    const mondayStart = await buildDataForWeek(START_DATE, makeSettings(1), getMealPlansForPeriod);
+    expect(mondayStart.endDate.getDate()).toBe(28);
+  });
+
+  it('passes the correct end date string to getMealPlansForPeriod based on weekStartDay', async () => {
+    const getMealPlansForPeriod = vi.fn().mockResolvedValue([]);
+    // weekStartsOn=1 (Monday): week is Dec 22–28, so end date is Dec 28
+    await buildDataForWeek(START_DATE, makeSettings(1), getMealPlansForPeriod);
+    expect(getMealPlansForPeriod).toHaveBeenCalledWith('2025-12-25', '2025-12-28');
+  });
+
+  it('returns the number of days that have meals', async () => {
+    const mealPlans = [
+      makeMealPlan('mp-1', 500, 30, 60),
+      makeMealPlan('mp-2', 600, 40, 70),
+      { ...makeMealPlan('mp-3', 0, 0, 0), meals: [] },
+    ];
+    const getMealPlansForPeriod = vi.fn().mockResolvedValue(mealPlans);
+    const result = await buildDataForWeek(START_DATE, makeSettings(), getMealPlansForPeriod);
+    expect(result.daysWithMeals).toBe(2);
+  });
+
+  it('calculates average calories, protein, and carbs over days with meals', async () => {
+    const mealPlans = [makeMealPlan('mp-1', 500, 31, 62), makeMealPlan('mp-2', 601, 41, 71)];
+    const getMealPlansForPeriod = vi.fn().mockResolvedValue(mealPlans);
+    const result = await buildDataForWeek(START_DATE, makeSettings(), getMealPlansForPeriod);
+    expect(result.averageCalories).toBe(Math.round((500 + 601) / 2));
+    expect(result.averageProtein).toBe(Math.round((31 + 41) / 2));
+    expect(result.averageCarbs).toBe(Math.round((62 + 71) / 2));
+  });
+
+  it('rounds averages to the nearest integer', async () => {
+    // 3 items summing to values that produce non-integer averages
+    const mealPlans = [
+      makeMealPlan('mp-1', 100, 10, 20),
+      makeMealPlan('mp-2', 200, 20, 30),
+      makeMealPlan('mp-3', 300, 30, 40),
+    ];
+    const getMealPlansForPeriod = vi.fn().mockResolvedValue(mealPlans);
+    const result = await buildDataForWeek(START_DATE, makeSettings(), getMealPlansForPeriod);
+    expect(Number.isInteger(result.averageCalories)).toBe(true);
+    expect(Number.isInteger(result.averageProtein)).toBe(true);
+    expect(Number.isInteger(result.averageCarbs)).toBe(true);
+  });
+
+  it('returns zero averages when there are no days with meals', async () => {
+    const getMealPlansForPeriod = vi.fn().mockResolvedValue([]);
+    const result = await buildDataForWeek(START_DATE, makeSettings(), getMealPlansForPeriod);
+    expect(result.averageCalories).toBe(0);
+    expect(result.averageProtein).toBe(0);
+    expect(result.averageCarbs).toBe(0);
+  });
+});

--- a/src/core/build-data-for-week.ts
+++ b/src/core/build-data-for-week.ts
@@ -1,6 +1,6 @@
 import type { Settings } from '@/models/settings';
 import { endOfWeek, format } from 'date-fns';
-import { daysWithMeals, multiDayMealPlanNutrients } from './nutritional-calculations';
+import { daysWithMeals, multiDayMealPlanNutrients } from '@/core/nutritional-calculations';
 import type { WeeklyData } from '@/models/weekly-data';
 import type { MealPlan } from '@/models/meal-plan';
 

--- a/src/core/build-data-for-week.ts
+++ b/src/core/build-data-for-week.ts
@@ -1,0 +1,26 @@
+import type { Settings } from '@/models/settings';
+import { endOfWeek, format } from 'date-fns';
+import { daysWithMeals, multiDayMealPlanNutrients } from './nutritional-calculations';
+import type { WeeklyData } from '@/models/weekly-data';
+import type { MealPlan } from '@/models/meal-plan';
+
+const dateToISO = (date: Date): string => format(date, 'yyyy-MM-dd');
+
+export const buildDataForWeek = async (
+  startDate: Date,
+  settings: Settings,
+  getMealPlansForPeriod: (beginDt: string, endDt: string) => Promise<MealPlan[]>,
+): Promise<WeeklyData> => {
+  const endDate = endOfWeek(startDate, { weekStartsOn: settings.weekStartDay });
+  const mealPlans = await getMealPlansForPeriod(dateToISO(startDate), dateToISO(endDate));
+  const days = daysWithMeals(mealPlans);
+  const nutrition = multiDayMealPlanNutrients(mealPlans);
+  return {
+    startDate,
+    endDate,
+    daysWithMeals: days,
+    averageCalories: Math.round(nutrition.calories / (days || 1)),
+    averageProtein: Math.round(nutrition.protein / (days || 1)),
+    averageCarbs: Math.round(nutrition.carbs / (days || 1)),
+  };
+};

--- a/src/pages/planning/index.vue
+++ b/src/pages/planning/index.vue
@@ -41,11 +41,11 @@
 </template>
 
 <script lang="ts" setup>
-import { daysWithMeals, multiDayMealPlanNutrients } from '@/core/nutritional-calculations';
+import { buildDataForWeek } from '@/core/build-data-for-week';
 import { useMealPlansData } from '@/data/meal-plans';
 import { useSettingsData } from '@/data/settings';
 import type { WeeklyData } from '@/models/weekly-data';
-import { addWeeks, differenceInWeeks, endOfWeek, format, startOfWeek } from 'date-fns';
+import { addWeeks, differenceInWeeks, format, startOfWeek } from 'date-fns';
 import { ref } from 'vue';
 import { useRouter } from 'vue-router';
 
@@ -60,28 +60,15 @@ const { getMealPlansForPeriod } = useMealPlansData();
 
 const dateToISO = (date: Date): string => format(date, 'yyyy-MM-dd');
 
-const buildDataForWeek = async (startDate: Date): Promise<WeeklyData> => {
-  const endDate = endOfWeek(startDate, { weekStartsOn: settings.value?.weekStartDay });
-  const mealPlans = await getMealPlansForPeriod(dateToISO(startDate), dateToISO(endDate));
-  const days = daysWithMeals(mealPlans);
-  const nutrition = multiDayMealPlanNutrients(mealPlans);
-  return {
-    startDate,
-    endDate,
-    daysWithMeals: days,
-    averageCalories: Math.round(nutrition.calories / (days || 1)),
-    averageProtein: Math.round(nutrition.protein / (days || 1)),
-    averageCarbs: Math.round(nutrition.carbs / (days || 1)),
-  };
-};
-
 settings.promise.value
   .then(async () => {
-    const start = startOfWeek(new Date(), { weekStartsOn: settings.value?.weekStartDay });
-    thisWeek.value = await buildDataForWeek(start);
-    nextWeek.value = await buildDataForWeek(addWeeks(start, 1));
+    const start = startOfWeek(new Date(), { weekStartsOn: settings.value!.weekStartDay });
+    thisWeek.value = await buildDataForWeek(start, settings.value!, getMealPlansForPeriod);
+    nextWeek.value = await buildDataForWeek(addWeeks(start, 1), settings.value!, getMealPlansForPeriod);
     const indices = [1, 2, 3, 4];
-    const previousWeekPromises = indices.map((i) => buildDataForWeek(addWeeks(start, -i)));
+    const previousWeekPromises = indices.map((i) =>
+      buildDataForWeek(addWeeks(start, -i), settings.value!, getMealPlansForPeriod),
+    );
     const loadedPreviousWeeks = await Promise.all(previousWeekPromises);
     loadedPreviousWeeks.sort((a, b) => b.startDate.getTime() - a.startDate.getTime());
     previousWeeks.value = loadedPreviousWeeks;

--- a/src/pages/planning/index.vue
+++ b/src/pages/planning/index.vue
@@ -62,12 +62,14 @@ const dateToISO = (date: Date): string => format(date, 'yyyy-MM-dd');
 
 settings.promise.value
   .then(async () => {
-    const start = startOfWeek(new Date(), { weekStartsOn: settings.value!.weekStartDay });
-    thisWeek.value = await buildDataForWeek(start, settings.value!, getMealPlansForPeriod);
-    nextWeek.value = await buildDataForWeek(addWeeks(start, 1), settings.value!, getMealPlansForPeriod);
+    const currentSettings = settings.value;
+    if (!currentSettings) return;
+    const start = startOfWeek(new Date(), { weekStartsOn: currentSettings.weekStartDay });
+    thisWeek.value = await buildDataForWeek(start, currentSettings, getMealPlansForPeriod);
+    nextWeek.value = await buildDataForWeek(addWeeks(start, 1), currentSettings, getMealPlansForPeriod);
     const indices = [1, 2, 3, 4];
     const previousWeekPromises = indices.map((i) =>
-      buildDataForWeek(addWeeks(start, -i), settings.value!, getMealPlansForPeriod),
+      buildDataForWeek(addWeeks(start, -i), currentSettings, getMealPlansForPeriod),
     );
     const loadedPreviousWeeks = await Promise.all(previousWeekPromises);
     loadedPreviousWeeks.sort((a, b) => b.startDate.getTime() - a.startDate.getTime());


### PR DESCRIPTION
`settings.value!` non-null assertions in `planning/index.vue` could throw at runtime if the Firestore settings document hasn't been created yet. The fix captures `settings.value` once into a local variable and returns early if it's missing, preserving the original safe behavior.

## Changes

- **`src/pages/planning/index.vue`**: Replace `settings.value!` assertions with a captured `currentSettings` local variable and an early-return guard

```typescript
.then(async () => {
  const currentSettings = settings.value;
  if (!currentSettings) return;
  const start = startOfWeek(new Date(), { weekStartsOn: currentSettings.weekStartDay });
  thisWeek.value = await buildDataForWeek(start, currentSettings, getMealPlansForPeriod);
  // ...
})
```