### PR TITLE
Removes cheat days and updates settings schema

### DIFF
--- a/.changeset/pretty-ends-cover.md
+++ b/.changeset/pretty-ends-cover.md
@@ -1,0 +1,5 @@
+---
+'meal-planner': minor
+---
+
+remove cheat days and modify the settings to use a target range for targetting nutritional stats, with sugar still only including a max value

--- a/.changeset/pretty-ends-cover.md
+++ b/.changeset/pretty-ends-cover.md
@@ -2,4 +2,4 @@
 'meal-planner': minor
 ---
 
-remove cheat days and modify the settings to use a target range for targetting nutritional stats, with sugar still only including a max value
+remove cheat days and modify the settings to use a target range for targeting nutritional stats, with sugar still only including a max value

--- a/src/components/settings/SettingsEditor.vue
+++ b/src/components/settings/SettingsEditor.vue
@@ -65,26 +65,26 @@ const daysOfTheWeek = [
 
 // Reactive properties to control the editor
 const valid = ref(false);
-const dailyCalorieLimit = ref<number>(props.settings.dailyCalorieLimit);
-const dailySugarLimit = ref<number>(props.settings.dailySugarLimit);
-const dailyProteinTarget = ref<number>(props.settings.dailyProteinTarget);
+const dailyCalorieLimit = ref<number>(props.settings.maxDailyCalories);
+const dailySugarLimit = ref<number>(props.settings.maxDailySugar);
+const dailyProteinTarget = ref<number>(props.settings.maxDailyProtein);
 const tolerance = ref<number>(props.settings.tolerance);
 const weekStartDay = ref<number>(props.settings.weekStartDay);
 
 const isModified = computed(() => {
   return (
-    dailyCalorieLimit.value !== props.settings.dailyCalorieLimit ||
-    dailySugarLimit.value !== props.settings.dailySugarLimit ||
-    dailyProteinTarget.value !== props.settings.dailyProteinTarget ||
+    dailyCalorieLimit.value !== props.settings.maxDailyCalories ||
+    dailySugarLimit.value !== props.settings.maxDailySugar ||
+    dailyProteinTarget.value !== props.settings.maxDailyProtein ||
     tolerance.value !== props.settings.tolerance ||
     weekStartDay.value !== props.settings.weekStartDay
   );
 });
 
 const reset = () => {
-  dailyCalorieLimit.value = props.settings.dailyCalorieLimit;
-  dailySugarLimit.value = props.settings.dailySugarLimit;
-  dailyProteinTarget.value = props.settings.dailyProteinTarget;
+  dailyCalorieLimit.value = props.settings.maxDailyCalories;
+  dailySugarLimit.value = props.settings.maxDailySugar;
+  dailyProteinTarget.value = props.settings.maxDailyProtein;
   tolerance.value = props.settings.tolerance;
   weekStartDay.value = props.settings.weekStartDay;
 };
@@ -93,9 +93,15 @@ watchEffect(() => reset());
 
 const save = () => {
   const updatedSettings: Settings = {
-    dailyCalorieLimit: dailyCalorieLimit.value,
-    dailySugarLimit: dailySugarLimit.value,
-    dailyProteinTarget: dailyProteinTarget.value,
+    minDailyCalories: dailyCalorieLimit.value,
+    maxDailyCalories: dailyCalorieLimit.value,
+    minDailyProtein: dailyProteinTarget.value,
+    maxDailyProtein: dailyProteinTarget.value,
+    minDailyCarbs: 0, // Carbs are not currently editable, so we set them to 0
+    maxDailyCarbs: 0,
+    minDailyFat: 0, // Fat is not currently editable, so we set it to 0
+    maxDailyFat: 0,
+    maxDailySugar: dailySugarLimit.value,
     tolerance: tolerance.value,
     weekStartDay: weekStartDay.value as WeekDay,
   };

--- a/src/components/settings/SettingsEditor.vue
+++ b/src/components/settings/SettingsEditor.vue
@@ -28,16 +28,6 @@
       ]"
       data-testid="tolerance-input"
     ></v-number-input>
-    <v-number-input
-      label="Cheat Days per Week"
-      v-model="cheatDays"
-      :rules="[
-        validationRules.required,
-        validationRules.zeroOrGreater,
-        (value) => value <= 7 || 'Cheat days must be 7 or fewer',
-      ]"
-      data-testid="cheat-days-input"
-    ></v-number-input>
     <v-autocomplete
       label="Week Start Day"
       v-model="weekStartDay"
@@ -79,7 +69,6 @@ const dailyCalorieLimit = ref<number>(props.settings.dailyCalorieLimit);
 const dailySugarLimit = ref<number>(props.settings.dailySugarLimit);
 const dailyProteinTarget = ref<number>(props.settings.dailyProteinTarget);
 const tolerance = ref<number>(props.settings.tolerance);
-const cheatDays = ref<number>(props.settings.cheatDays);
 const weekStartDay = ref<number>(props.settings.weekStartDay);
 
 const isModified = computed(() => {
@@ -88,7 +77,6 @@ const isModified = computed(() => {
     dailySugarLimit.value !== props.settings.dailySugarLimit ||
     dailyProteinTarget.value !== props.settings.dailyProteinTarget ||
     tolerance.value !== props.settings.tolerance ||
-    cheatDays.value !== props.settings.cheatDays ||
     weekStartDay.value !== props.settings.weekStartDay
   );
 });
@@ -98,7 +86,6 @@ const reset = () => {
   dailySugarLimit.value = props.settings.dailySugarLimit;
   dailyProteinTarget.value = props.settings.dailyProteinTarget;
   tolerance.value = props.settings.tolerance;
-  cheatDays.value = props.settings.cheatDays;
   weekStartDay.value = props.settings.weekStartDay;
 };
 
@@ -110,7 +97,6 @@ const save = () => {
     dailySugarLimit: dailySugarLimit.value,
     dailyProteinTarget: dailyProteinTarget.value,
     tolerance: tolerance.value,
-    cheatDays: cheatDays.value,
     weekStartDay: weekStartDay.value as WeekDay,
   };
   emit('save', updatedSettings);

--- a/src/components/settings/__tests__/SettingsEditor.spec.ts
+++ b/src/components/settings/__tests__/SettingsEditor.spec.ts
@@ -18,9 +18,15 @@ const vuetify = createVuetify({
 const mountComponent = (
   props: { settings: Settings } = {
     settings: {
-      dailyCalorieLimit: 1875,
-      dailySugarLimit: 45,
-      dailyProteinTarget: 65,
+      minDailyCalories: 1500,
+      maxDailyCalories: 1875,
+      minDailyProtein: 50,
+      maxDailyProtein: 65,
+      minDailyFat: 50,
+      maxDailyFat: 70,
+      minDailyCarbs: 200,
+      maxDailyCarbs: 250,
+      maxDailySugar: 45,
       tolerance: 8,
       weekStartDay: 2,
     },
@@ -333,9 +339,15 @@ describe('SettingsEditor', () => {
       expect(wrapper.emitted('save')?.length).toBe(1);
       expect(wrapper.emitted('save')?.[0]).toEqual([
         {
-          dailyCalorieLimit: 2100,
-          dailySugarLimit: 55,
-          dailyProteinTarget: 80,
+          minDailyCalories: 2100,
+          maxDailyCalories: 2100,
+          minDailyProtein: 80,
+          maxDailyProtein: 80,
+          minDailyFat: 0,
+          maxDailyFat: 0,
+          minDailyCarbs: 0,
+          maxDailyCarbs: 0,
+          maxDailySugar: 55,
           tolerance: 12,
           weekStartDay: 1,
         },
@@ -347,9 +359,15 @@ describe('SettingsEditor', () => {
     it('resets form when settings prop changes', async () => {
       wrapper = mountComponent({
         settings: {
-          dailyCalorieLimit: 1800,
-          dailySugarLimit: 40,
-          dailyProteinTarget: 60,
+          minDailyCalories: 1500,
+          maxDailyCalories: 1800,
+          minDailyProtein: 50,
+          maxDailyProtein: 60,
+          minDailyFat: 50,
+          maxDailyFat: 70,
+          minDailyCarbs: 200,
+          maxDailyCarbs: 250,
+          maxDailySugar: 40,
           tolerance: 5,
           weekStartDay: 1,
         },
@@ -369,9 +387,15 @@ describe('SettingsEditor', () => {
       // Update props - watchEffect should reset the form
       await wrapper.setProps({
         settings: {
-          dailyCalorieLimit: 2200,
-          dailySugarLimit: 50,
-          dailyProteinTarget: 70,
+          minDailyCalories: 1850,
+          maxDailyCalories: 2200,
+          minDailyProtein: 55,
+          maxDailyProtein: 70,
+          minDailyFat: 50,
+          maxDailyFat: 70,
+          minDailyCarbs: 200,
+          maxDailyCarbs: 250,
+          maxDailySugar: 50,
           tolerance: 10,
           weekStartDay: 0,
         },
@@ -405,9 +429,15 @@ describe('SettingsEditor', () => {
     it('resets isModified state when props change', async () => {
       wrapper = mountComponent({
         settings: {
-          dailyCalorieLimit: 1800,
-          dailySugarLimit: 40,
-          dailyProteinTarget: 60,
+          minDailyCalories: 1500,
+          maxDailyCalories: 1800,
+          maxDailySugar: 40,
+          minDailyProtein: 50,
+          maxDailyProtein: 60,
+          minDailyFat: 50,
+          maxDailyFat: 70,
+          minDailyCarbs: 200,
+          maxDailyCarbs: 250,
           tolerance: 5,
           weekStartDay: 1,
         },
@@ -431,9 +461,15 @@ describe('SettingsEditor', () => {
       // Update props - should reset and disable save button
       await wrapper.setProps({
         settings: {
-          dailyCalorieLimit: 2200,
-          dailySugarLimit: 50,
-          dailyProteinTarget: 70,
+          minDailyCalories: 1850,
+          maxDailyCalories: 2200,
+          maxDailySugar: 50,
+          minDailyProtein: 55,
+          maxDailyProtein: 70,
+          minDailyFat: 50,
+          maxDailyFat: 70,
+          minDailyCarbs: 200,
+          maxDailyCarbs: 250,
           tolerance: 10,
           weekStartDay: 0,
         },

--- a/src/components/settings/__tests__/SettingsEditor.spec.ts
+++ b/src/components/settings/__tests__/SettingsEditor.spec.ts
@@ -22,7 +22,6 @@ const mountComponent = (
       dailySugarLimit: 45,
       dailyProteinTarget: 65,
       tolerance: 8,
-      cheatDays: 3,
       weekStartDay: 2,
     },
   },
@@ -177,52 +176,6 @@ describe('SettingsEditor', () => {
     });
   });
 
-  describe('Cheat Days', () => {
-    it('renders', () => {
-      wrapper = mountComponent();
-      const caloriesInput = wrapper.findComponent(
-        '[data-testid="cheat-days-input"]',
-      ) as VueWrapper<components.VNumberInput>;
-      expect(caloriesInput.exists()).toBe(true);
-      expect(caloriesInput.props('label')).toBe('Cheat Days per Week');
-    });
-
-    it('is required', async () => {
-      wrapper = mountComponent();
-      await numberInputIsRequired(wrapper, 'cheat-days-input');
-    });
-
-    it('must be zero or greater', async () => {
-      wrapper = mountComponent();
-      await numberInputMustBeZeroOrGreater(wrapper, 'cheat-days-input');
-    });
-
-    it('must be seven or less', async () => {
-      wrapper = mountComponent();
-      const caloriesInput = wrapper.findComponent(
-        '[data-testid="cheat-days-input"]',
-      ) as VueWrapper<components.VNumberInput>;
-      const input = caloriesInput.find('input');
-
-      expect(caloriesInput.text()).not.toContain('must be 7 or fewer');
-      await input.trigger('focus');
-      await input.setValue(8);
-      await input.trigger('blur');
-      expect(caloriesInput.text()).toContain('must be 7 or fewer');
-      await input.setValue(7);
-      await input.trigger('blur');
-      expect(caloriesInput.text()).not.toContain('must be 7 or fewer');
-    });
-
-    it('is initialized based on the settings', () => {
-      wrapper = mountComponent();
-      const caloriesInput = wrapper.findComponent(
-        '[data-testid="cheat-days-input"]',
-      ) as VueWrapper<components.VNumberInput>;
-      expect(caloriesInput.props('modelValue')).toBe(3);
-    });
-  });
-
   describe('Week Start Day', () => {
     it('renders', () => {
       wrapper = mountComponent();
@@ -282,9 +235,6 @@ describe('SettingsEditor', () => {
       const toleranceInput = wrapper.findComponent(
         '[data-testid="tolerance-input"]',
       ) as VueWrapper<components.VNumberInput>;
-      const cheatDaysInput = wrapper.findComponent(
-        '[data-testid="cheat-days-input"]',
-      ) as VueWrapper<components.VNumberInput>;
       const weekStartDayInput = wrapper.findComponent(
         '[data-testid="week-start-day-input"]',
       ) as VueWrapper<components.VAutocomplete>;
@@ -293,7 +243,6 @@ describe('SettingsEditor', () => {
       await sugarInput.setValue(55);
       await proteinInput.setValue(80);
       await toleranceInput.setValue(12);
-      await cheatDaysInput.setValue(2);
       await weekStartDayInput.setValue(1);
 
       const resetButton = wrapper.find('[data-testid="reset-button"]');
@@ -303,7 +252,6 @@ describe('SettingsEditor', () => {
       expect(sugarInput.props('modelValue')).toBe(45);
       expect(proteinInput.props('modelValue')).toBe(65);
       expect(toleranceInput.props('modelValue')).toBe(8);
-      expect(cheatDaysInput.props('modelValue')).toBe(3);
       expect(weekStartDayInput.props('modelValue')).toBe(2);
     });
 
@@ -367,9 +315,6 @@ describe('SettingsEditor', () => {
       const toleranceInput = wrapper.findComponent(
         '[data-testid="tolerance-input"]',
       ) as VueWrapper<components.VNumberInput>;
-      const cheatDaysInput = wrapper.findComponent(
-        '[data-testid="cheat-days-input"]',
-      ) as VueWrapper<components.VNumberInput>;
       const weekStartDayInput = wrapper.findComponent(
         '[data-testid="week-start-day-input"]',
       ) as VueWrapper<components.VAutocomplete>;
@@ -378,7 +323,6 @@ describe('SettingsEditor', () => {
       await sugarInput.setValue(55);
       await proteinInput.setValue(80);
       await toleranceInput.setValue(12);
-      await cheatDaysInput.setValue(2);
       await weekStartDayInput.setValue(1);
       await flushPromises();
 
@@ -393,7 +337,6 @@ describe('SettingsEditor', () => {
           dailySugarLimit: 55,
           dailyProteinTarget: 80,
           tolerance: 12,
-          cheatDays: 2,
           weekStartDay: 1,
         },
       ]);
@@ -408,7 +351,6 @@ describe('SettingsEditor', () => {
           dailySugarLimit: 40,
           dailyProteinTarget: 60,
           tolerance: 5,
-          cheatDays: 2,
           weekStartDay: 1,
         },
       });
@@ -431,7 +373,6 @@ describe('SettingsEditor', () => {
           dailySugarLimit: 50,
           dailyProteinTarget: 70,
           tolerance: 10,
-          cheatDays: 1,
           weekStartDay: 0,
         },
       });
@@ -455,11 +396,6 @@ describe('SettingsEditor', () => {
       ) as VueWrapper<components.VNumberInput>;
       expect(toleranceInput.props('modelValue')).toBe(10);
 
-      const cheatDaysInput = wrapper.findComponent(
-        '[data-testid="cheat-days-input"]',
-      ) as VueWrapper<components.VNumberInput>;
-      expect(cheatDaysInput.props('modelValue')).toBe(1);
-
       const weekStartDayInput = wrapper.findComponent(
         '[data-testid="week-start-day-input"]',
       ) as VueWrapper<components.VAutocomplete>;
@@ -473,7 +409,6 @@ describe('SettingsEditor', () => {
           dailySugarLimit: 40,
           dailyProteinTarget: 60,
           tolerance: 5,
-          cheatDays: 2,
           weekStartDay: 1,
         },
       });
@@ -500,7 +435,6 @@ describe('SettingsEditor', () => {
           dailySugarLimit: 50,
           dailyProteinTarget: 70,
           tolerance: 10,
-          cheatDays: 1,
           weekStartDay: 0,
         },
       });

--- a/src/core/__tests__/build-weekly-data.spec.ts
+++ b/src/core/__tests__/build-weekly-data.spec.ts
@@ -8,7 +8,6 @@ const makeSettings = (weekStartDay: 0 | 1 = 0): Settings => ({
   dailySugarLimit: 50,
   dailyProteinTarget: 150,
   tolerance: 10,
-  cheatDays: 1,
   weekStartDay,
 });
 

--- a/src/core/__tests__/build-weekly-data.spec.ts
+++ b/src/core/__tests__/build-weekly-data.spec.ts
@@ -4,9 +4,15 @@ import { describe, expect, it, vi } from 'vitest';
 import { buildWeeklyData } from '../build-weekly-data';
 
 const makeSettings = (weekStartDay: 0 | 1 = 0): Settings => ({
-  dailyCalorieLimit: 2000,
-  dailySugarLimit: 50,
-  dailyProteinTarget: 150,
+  minDailyCalories: 2000,
+  maxDailyCalories: 2500,
+  minDailyProtein: 50,
+  maxDailyProtein: 150,
+  minDailyCarbs: 100,
+  maxDailyCarbs: 300,
+  minDailyFat: 20,
+  maxDailyFat: 70,
+  maxDailySugar: 50,
   tolerance: 10,
   weekStartDay,
 });

--- a/src/data/__mocks__/settings.ts
+++ b/src/data/__mocks__/settings.ts
@@ -12,9 +12,15 @@ interface SettingsData {
 
 const updateSettings = vi.fn();
 const settings = ref<Settings>({
-  dailyCalorieLimit: 2500,
-  dailySugarLimit: 35,
-  dailyProteinTarget: 85,
+  minDailyCalories: 1500,
+  maxDailyCalories: 2500,
+  minDailyProtein: 85,
+  maxDailyProtein: 150,
+  minDailyCarbs: 130,
+  maxDailyCarbs: 300,
+  minDailyFat: 20,
+  maxDailyFat: 70,
+  maxDailySugar: 35,
   tolerance: 15,
   weekStartDay: 1,
 });

--- a/src/data/__mocks__/settings.ts
+++ b/src/data/__mocks__/settings.ts
@@ -16,7 +16,6 @@ const settings = ref<Settings>({
   dailySugarLimit: 35,
   dailyProteinTarget: 85,
   tolerance: 15,
-  cheatDays: 2,
   weekStartDay: 1,
 });
 (settings as any).promise = { value: Promise.resolve(settings.value) };

--- a/src/data/__tests__/settings.spec.ts
+++ b/src/data/__tests__/settings.spec.ts
@@ -199,6 +199,5 @@ const DEFAULT_SETTINGS: Settings = {
   dailySugarLimit: 50,
   dailyProteinTarget: 75,
   tolerance: 10,
-  cheatDays: 1,
   weekStartDay: 0,
 };

--- a/src/data/__tests__/settings.spec.ts
+++ b/src/data/__tests__/settings.spec.ts
@@ -195,9 +195,15 @@ describe('Settings Data Service', () => {
 });
 
 const DEFAULT_SETTINGS: Settings = {
-  dailyCalorieLimit: 2000,
-  dailySugarLimit: 50,
-  dailyProteinTarget: 75,
+  minDailyCalories: 1950,
+  maxDailyCalories: 2150,
+  minDailyProtein: 140,
+  maxDailyProtein: 160,
+  minDailyCarbs: 210,
+  maxDailyCarbs: 235,
+  minDailyFat: 60,
+  maxDailyFat: 75,
+  maxDailySugar: 38,
   tolerance: 10,
   weekStartDay: 0,
 };

--- a/src/data/settings.ts
+++ b/src/data/settings.ts
@@ -8,7 +8,6 @@ const DEFAULT_SETTINGS: Settings = {
   dailySugarLimit: 50,
   dailyProteinTarget: 75,
   tolerance: 10,
-  cheatDays: 1,
   weekStartDay: 0, // Sunday
 };
 

--- a/src/data/settings.ts
+++ b/src/data/settings.ts
@@ -4,11 +4,17 @@ import { computed } from 'vue';
 import { useDocument, useFirestore } from 'vuefire';
 
 const DEFAULT_SETTINGS: Settings = {
-  dailyCalorieLimit: 2000,
-  dailySugarLimit: 50,
-  dailyProteinTarget: 75,
+  minDailyCalories: 1950,
+  maxDailyCalories: 2150,
+  minDailyProtein: 140,
+  maxDailyProtein: 160,
+  minDailyCarbs: 210,
+  maxDailyCarbs: 235,
+  minDailyFat: 60,
+  maxDailyFat: 75,
+  maxDailySugar: 38,
   tolerance: 10,
-  weekStartDay: 0, // Sunday
+  weekStartDay: 0,
 };
 
 export const useSettingsData = () => {

--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -13,8 +13,8 @@ export interface Settings {
   maxDailyProtein: number;
   minDailyCarbs: number;
   maxDailyCarbs: number;
-  minDailyFats: number;
-  maxDailyFats: number;
+  minDailyFat: number;
+  maxDailyFat: number;
   maxDailySugar: number;
   /**
    * Acceptable percentage deviation above a maximum or below a minimum for calorie and nutrient goals.

--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -18,8 +18,6 @@ export interface Settings {
    * Must be between 0 and 100 (inclusive). Validation is performed at runtime when updating settings.
    */
   tolerance: number;
-  /** Number of cheat days allowed per week */
-  cheatDays: number;
   /** First day of the week (0 = Sunday, 1 = Monday, etc.) */
   weekStartDay: WeekDay;
 }

--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -19,7 +19,8 @@ export interface Settings {
   /**
    * Acceptable percentage deviation above a maximum or below a minimum for calorie and nutrient goals.
    * This is used to determine when to show warnings about exceeding limits or not meeting targets.
-   * Must be between 0 and 100 (inclusive). Validation is performed at runtime when updating settings.
+   * Expected to be between 0 and 100 (inclusive). This interface does not enforce runtime validation;
+   * callers such as UI forms are responsible for providing a value in that range.
    */
   tolerance: number;
   /** First day of the week (0 = Sunday, 1 = Monday, etc.) */

--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -7,14 +7,18 @@ export type WeekDay = 0 | 1 | 2 | 3 | 4 | 5 | 6;
  * User settings for meal planning and nutritional goals
  */
 export interface Settings {
-  /** Daily calorie target in kcal */
-  dailyCalorieLimit: number;
-  /** Daily sugar limit in grams */
-  dailySugarLimit: number;
-  /** Daily protein target in grams */
-  dailyProteinTarget: number;
+  minDailyCalories: number;
+  maxDailyCalories: number;
+  minDailyProtein: number;
+  maxDailyProtein: number;
+  minDailyCarbs: number;
+  maxDailyCarbs: number;
+  minDailyFats: number;
+  maxDailyFats: number;
+  maxDailySugar: number;
   /**
-   * Acceptable percentage deviation from nutritional targets before the day counts as a cheat day.
+   * Acceptable percentage deviation above a maximum or below a minimum for calorie and nutrient goals.
+   * This is used to determine when to show warnings about exceeding limits or not meeting targets.
    * Must be between 0 and 100 (inclusive). Validation is performed at runtime when updating settings.
    */
   tolerance: number;

--- a/src/pages/__tests__/settings.spec.ts
+++ b/src/pages/__tests__/settings.spec.ts
@@ -47,9 +47,15 @@ describe('SettingsPage', () => {
     const settingsEditor = wrapper.findComponent({ name: 'SettingsEditor' });
     expect(settingsEditor.exists()).toBe(true);
     expect(settingsEditor.props('settings')).toEqual({
-      dailyCalorieLimit: 2500,
-      dailySugarLimit: 35,
-      dailyProteinTarget: 85,
+      minDailyCalories: 1500,
+      maxDailyCalories: 2500,
+      minDailyProtein: 85,
+      maxDailyProtein: 150,
+      minDailyCarbs: 130,
+      maxDailyCarbs: 300,
+      minDailyFat: 20,
+      maxDailyFat: 70,
+      maxDailySugar: 35,
       tolerance: 15,
       weekStartDay: 1,
     });
@@ -61,9 +67,15 @@ describe('SettingsPage', () => {
     const { updateSettings } = useSettingsData();
 
     const updatedSettings = {
-      dailyCalorieLimit: 2100,
-      dailySugarLimit: 45,
-      dailyProteinTarget: 90,
+      minDailyCalories: 1950,
+      maxDailyCalories: 2150,
+      minDailyProtein: 140,
+      maxDailyProtein: 160,
+      minDailyCarbs: 210,
+      maxDailyCarbs: 235,
+      minDailyFat: 60,
+      maxDailyFat: 75,
+      maxDailySugar: 38,
       tolerance: 12,
       weekStartDay: 0,
     };

--- a/src/pages/__tests__/settings.spec.ts
+++ b/src/pages/__tests__/settings.spec.ts
@@ -51,7 +51,6 @@ describe('SettingsPage', () => {
       dailySugarLimit: 35,
       dailyProteinTarget: 85,
       tolerance: 15,
-      cheatDays: 2,
       weekStartDay: 1,
     });
   });
@@ -66,7 +65,6 @@ describe('SettingsPage', () => {
       dailySugarLimit: 45,
       dailyProteinTarget: 90,
       tolerance: 12,
-      cheatDays: 1,
       weekStartDay: 0,
     };
 

--- a/src/pages/planning/__tests__/index.spec.ts
+++ b/src/pages/planning/__tests__/index.spec.ts
@@ -265,9 +265,15 @@ describe('Planning', () => {
 
       describe('with weekStartDay: 5 (Friday)', () => {
         const fridaySettings = ref<Settings>({
-          dailyCalorieLimit: 2500,
-          dailySugarLimit: 35,
-          dailyProteinTarget: 85,
+          minDailyCalories: 1950,
+          maxDailyCalories: 2150,
+          minDailyProtein: 140,
+          maxDailyProtein: 160,
+          minDailyCarbs: 210,
+          maxDailyCarbs: 235,
+          minDailyFat: 60,
+          maxDailyFat: 75,
+          maxDailySugar: 38,
           tolerance: 15,
           weekStartDay: 5,
         });

--- a/src/pages/planning/__tests__/index.spec.ts
+++ b/src/pages/planning/__tests__/index.spec.ts
@@ -269,7 +269,6 @@ describe('Planning', () => {
           dailySugarLimit: 35,
           dailyProteinTarget: 85,
           tolerance: 15,
-          cheatDays: 2,
           weekStartDay: 5,
         });
         (fridaySettings as any).promise = { value: Promise.resolve(fridaySettings.value) };


### PR DESCRIPTION
Remove the 'cheat days' setting and migrate nutritional goals to a min/max target range schema for calories, protein, carbohydrates, and fat, while retaining a maximum limit for sugar.

**IMPORTANT** this does **NOT** include changes to the UI/UX of the settings page. That will be included in another sub-task of the parent feature. Also, we are not worried about the breaking changes as this is still pre-release.

Relates to #341