### PR TITLE
Differentiate low and high nutritional status warnings

### DIFF
--- a/src/components/core/NutritionalStatusMarker.vue
+++ b/src/components/core/NutritionalStatusMarker.vue
@@ -1,10 +1,40 @@
 <template>
   <span>
-    <v-icon v-if="status === 'in-zone'" icon="mdi-circle" color="success" />
-    <v-icon v-if="status === 'low-warn'" icon="mdi-arrow-down-bold" color="warning" />
-    <v-icon v-if="status === 'low-danger'" icon="mdi-arrow-down-bold" color="error" />
-    <v-icon v-if="status === 'high-warn'" icon="mdi-arrow-up-bold" color="warning" />
-    <v-icon v-if="status === 'high-danger'" icon="mdi-arrow-up-bold" color="error" />
+    <v-icon
+      v-if="status === 'in-zone'"
+      icon="mdi-circle"
+      color="success"
+      aria-label="In zone"
+      title="In zone"
+    />
+    <v-icon
+      v-if="status === 'low-warn'"
+      icon="mdi-arrow-down-bold"
+      color="warning"
+      aria-label="Low warning"
+      title="Low warning"
+    />
+    <v-icon
+      v-if="status === 'low-danger'"
+      icon="mdi-arrow-down-bold"
+      color="error"
+      aria-label="Low danger"
+      title="Low danger"
+    />
+    <v-icon
+      v-if="status === 'high-warn'"
+      icon="mdi-arrow-up-bold"
+      color="warning"
+      aria-label="High warning"
+      title="High warning"
+    />
+    <v-icon
+      v-if="status === 'high-danger'"
+      icon="mdi-arrow-up-bold"
+      color="error"
+      aria-label="High danger"
+      title="High danger"
+    />
   </span>
 </template>
 

--- a/src/components/core/NutritionalStatusMarker.vue
+++ b/src/components/core/NutritionalStatusMarker.vue
@@ -1,12 +1,20 @@
 <template>
   <span>
-    <span v-if="status === 'green'" role="img" aria-label="Green nutritional status" title="Green nutritional status"
+    <span v-if="status === 'in-zone'" role="img" aria-label="Green nutritional status" title="Green nutritional status"
       >🟢</span
     >
-    <span v-if="status === 'yellow'" role="img" aria-label="Yellow nutritional status" title="Yellow nutritional status"
+    <span
+      v-if="status === 'high-warn' || status === 'low-warn'"
+      role="img"
+      aria-label="Yellow nutritional status"
+      title="Yellow nutritional status"
       >🟡</span
     >
-    <span v-if="status === 'red'" role="img" aria-label="Red nutritional status" title="Red nutritional status"
+    <span
+      v-if="status === 'high-danger' || status === 'low-danger'"
+      role="img"
+      aria-label="Red nutritional status"
+      title="Red nutritional status"
       >🔴</span
     >
   </span>

--- a/src/components/core/NutritionalStatusMarker.vue
+++ b/src/components/core/NutritionalStatusMarker.vue
@@ -1,22 +1,10 @@
 <template>
   <span>
-    <span v-if="status === 'in-zone'" role="img" aria-label="Green nutritional status" title="Green nutritional status"
-      >🟢</span
-    >
-    <span
-      v-if="status === 'high-warn' || status === 'low-warn'"
-      role="img"
-      aria-label="Yellow nutritional status"
-      title="Yellow nutritional status"
-      >🟡</span
-    >
-    <span
-      v-if="status === 'high-danger' || status === 'low-danger'"
-      role="img"
-      aria-label="Red nutritional status"
-      title="Red nutritional status"
-      >🔴</span
-    >
+    <v-icon v-if="status === 'in-zone'" icon="mdi-circle" color="success" />
+    <v-icon v-if="status === 'low-warn'" icon="mdi-arrow-down-bold" color="warning" />
+    <v-icon v-if="status === 'low-danger'" icon="mdi-arrow-down-bold" color="error" />
+    <v-icon v-if="status === 'high-warn'" icon="mdi-arrow-up-bold" color="warning" />
+    <v-icon v-if="status === 'high-danger'" icon="mdi-arrow-up-bold" color="error" />
   </span>
 </template>
 

--- a/src/components/core/__tests__/NutritionalStatusMarker.spec.ts
+++ b/src/components/core/__tests__/NutritionalStatusMarker.spec.ts
@@ -14,26 +14,40 @@ describe('Nutritional Status Marker', () => {
   });
 
   it('renders', () => {
-    wrapper = mountComponent('green');
+    wrapper = mountComponent('in-zone');
     expect(wrapper.exists()).toBe(true);
   });
 
-  it('displays the green indicator when status is green', () => {
-    wrapper = mountComponent('green');
+  it('displays the green indicator when status is in-zone', () => {
+    wrapper = mountComponent('in-zone');
     expect(wrapper.text()).toContain('🟢');
     expect(wrapper.text()).not.toContain('🟡');
     expect(wrapper.text()).not.toContain('🔴');
   });
 
-  it('displays the yellow indicator when status is yellow', () => {
-    wrapper = mountComponent('yellow');
+  it('displays the yellow indicator when status is low-warn', () => {
+    wrapper = mountComponent('low-warn');
     expect(wrapper.text()).toContain('🟡');
     expect(wrapper.text()).not.toContain('🟢');
     expect(wrapper.text()).not.toContain('🔴');
   });
 
-  it('displays the red indicator when status is red', () => {
-    wrapper = mountComponent('red');
+  it('displays the red indicator when status is low-danger', () => {
+    wrapper = mountComponent('low-danger');
+    expect(wrapper.text()).toContain('🔴');
+    expect(wrapper.text()).not.toContain('🟢');
+    expect(wrapper.text()).not.toContain('🟡');
+  });
+
+  it('displays the yellow indicator when status is high-warn', () => {
+    wrapper = mountComponent('high-warn');
+    expect(wrapper.text()).toContain('🟡');
+    expect(wrapper.text()).not.toContain('🟢');
+    expect(wrapper.text()).not.toContain('🔴');
+  });
+
+  it('displays the red indicator when status is high-danger', () => {
+    wrapper = mountComponent('low-danger');
     expect(wrapper.text()).toContain('🔴');
     expect(wrapper.text()).not.toContain('🟢');
     expect(wrapper.text()).not.toContain('🟡');

--- a/src/components/core/__tests__/NutritionalStatusMarker.spec.ts
+++ b/src/components/core/__tests__/NutritionalStatusMarker.spec.ts
@@ -1,9 +1,15 @@
 import { mount } from '@vue/test-utils';
 import { afterEach, describe, expect, it } from 'vitest';
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
 import NutritionalStatusMarker from '../NutritionalStatusMarker.vue';
 import type { NutritionalStatus } from '@/core/nutritional-status';
 
-const mountComponent = (status: NutritionalStatus | null) => mount(NutritionalStatusMarker, { props: { status } });
+const vuetify = createVuetify({ components, directives });
+
+const mountComponent = (status: NutritionalStatus | null) =>
+  mount(NutritionalStatusMarker, { props: { status }, global: { plugins: [vuetify] } });
 
 describe('Nutritional Status Marker', () => {
   let wrapper: ReturnType<typeof mountComponent> | undefined;
@@ -18,45 +24,48 @@ describe('Nutritional Status Marker', () => {
     expect(wrapper.exists()).toBe(true);
   });
 
-  it('displays the green indicator when status is in-zone', () => {
+  it('displays the success circle icon when status is in-zone', () => {
     wrapper = mountComponent('in-zone');
-    expect(wrapper.text()).toContain('🟢');
-    expect(wrapper.text()).not.toContain('🟡');
-    expect(wrapper.text()).not.toContain('🔴');
+    expect(wrapper.html()).toContain('mdi-circle');
+    expect(wrapper.html()).toContain('text-success');
+    expect(wrapper.html()).not.toContain('mdi-arrow');
   });
 
-  it('displays the yellow indicator when status is low-warn', () => {
+  it('displays the warning down arrow when status is low-warn', () => {
     wrapper = mountComponent('low-warn');
-    expect(wrapper.text()).toContain('🟡');
-    expect(wrapper.text()).not.toContain('🟢');
-    expect(wrapper.text()).not.toContain('🔴');
+    expect(wrapper.html()).toContain('mdi-arrow-down-bold');
+    expect(wrapper.html()).toContain('text-warning');
+    expect(wrapper.html()).not.toContain('mdi-circle');
+    expect(wrapper.html()).not.toContain('text-error');
   });
 
-  it('displays the red indicator when status is low-danger', () => {
+  it('displays the error down arrow when status is low-danger', () => {
     wrapper = mountComponent('low-danger');
-    expect(wrapper.text()).toContain('🔴');
-    expect(wrapper.text()).not.toContain('🟢');
-    expect(wrapper.text()).not.toContain('🟡');
+    expect(wrapper.html()).toContain('mdi-arrow-down-bold');
+    expect(wrapper.html()).toContain('text-error');
+    expect(wrapper.html()).not.toContain('mdi-circle');
+    expect(wrapper.html()).not.toContain('text-warning');
   });
 
-  it('displays the yellow indicator when status is high-warn', () => {
+  it('displays the warning up arrow when status is high-warn', () => {
     wrapper = mountComponent('high-warn');
-    expect(wrapper.text()).toContain('🟡');
-    expect(wrapper.text()).not.toContain('🟢');
-    expect(wrapper.text()).not.toContain('🔴');
+    expect(wrapper.html()).toContain('mdi-arrow-up-bold');
+    expect(wrapper.html()).toContain('text-warning');
+    expect(wrapper.html()).not.toContain('mdi-circle');
+    expect(wrapper.html()).not.toContain('text-error');
   });
 
-  it('displays the red indicator when status is high-danger', () => {
-    wrapper = mountComponent('low-danger');
-    expect(wrapper.text()).toContain('🔴');
-    expect(wrapper.text()).not.toContain('🟢');
-    expect(wrapper.text()).not.toContain('🟡');
+  it('displays the error up arrow when status is high-danger', () => {
+    wrapper = mountComponent('high-danger');
+    expect(wrapper.html()).toContain('mdi-arrow-up-bold');
+    expect(wrapper.html()).toContain('text-error');
+    expect(wrapper.html()).not.toContain('mdi-circle');
+    expect(wrapper.html()).not.toContain('text-warning');
   });
 
   it('displays nothing when status is null', () => {
     wrapper = mountComponent(null);
-    expect(wrapper.text()).not.toContain('🟢');
-    expect(wrapper.text()).not.toContain('🟡');
-    expect(wrapper.text()).not.toContain('🔴');
+    expect(wrapper.html()).not.toContain('mdi-circle');
+    expect(wrapper.html()).not.toContain('mdi-arrow');
   });
 });

--- a/src/components/portions/__tests__/NutritionData.spec.ts
+++ b/src/components/portions/__tests__/NutritionData.spec.ts
@@ -105,49 +105,52 @@ describe('NutritionData', () => {
       it('is not displayed when settings are not provided', () => {
         wrapper = mountComponent({ value: TEST_PORTION });
         const cell = wrapper.find(`[data-testid="${statistic}"]`);
-        expect(cell.text()).not.toContain('🟢');
-        expect(cell.text()).not.toContain('🟡');
-        expect(cell.text()).not.toContain('🔴');
+        expect(cell.html()).not.toContain('mdi-circle');
+        expect(cell.html()).not.toContain('mdi-arrow');
       });
 
-      it('displays the green indicator when the value is in range', () => {
+      it('displays the success circle icon when the value is in range', () => {
         wrapper = mountComponent({ value: greenPortion, settings: BASE_SETTINGS });
         const cell = wrapper.find(`[data-testid="${statistic}"]`);
-        expect(cell.text()).toContain('🟢');
-        expect(cell.text()).not.toContain('🟡');
-        expect(cell.text()).not.toContain('🔴');
+        expect(cell.html()).toContain('mdi-circle');
+        expect(cell.html()).toContain('text-success');
+        expect(cell.html()).not.toContain('mdi-arrow');
       });
 
-      it('displays the yellow indicator when the value is below min but within tolerance', () => {
+      it('displays the warning down arrow when the value is below min but within tolerance', () => {
         wrapper = mountComponent({ value: lowYellowPortion, settings: BASE_SETTINGS });
         const cell = wrapper.find(`[data-testid="${statistic}"]`);
-        expect(cell.text()).toContain('🟡');
-        expect(cell.text()).not.toContain('🟢');
-        expect(cell.text()).not.toContain('🔴');
+        expect(cell.html()).toContain('mdi-arrow-down-bold');
+        expect(cell.html()).toContain('text-warning');
+        expect(cell.html()).not.toContain('mdi-circle');
+        expect(cell.html()).not.toContain('text-error');
       });
 
-      it('displays the red indicator when the value is below min and beyond tolerance', () => {
+      it('displays the error down arrow when the value is below min and beyond tolerance', () => {
         wrapper = mountComponent({ value: lowRedPortion, settings: BASE_SETTINGS });
         const cell = wrapper.find(`[data-testid="${statistic}"]`);
-        expect(cell.text()).toContain('🔴');
-        expect(cell.text()).not.toContain('🟢');
-        expect(cell.text()).not.toContain('🟡');
+        expect(cell.html()).toContain('mdi-arrow-down-bold');
+        expect(cell.html()).toContain('text-error');
+        expect(cell.html()).not.toContain('mdi-circle');
+        expect(cell.html()).not.toContain('text-warning');
       });
 
-      it('displays the yellow indicator when the value is above max but within tolerance', () => {
+      it('displays the warning up arrow when the value is above max but within tolerance', () => {
         wrapper = mountComponent({ value: highYellowPortion, settings: BASE_SETTINGS });
         const cell = wrapper.find(`[data-testid="${statistic}"]`);
-        expect(cell.text()).toContain('🟡');
-        expect(cell.text()).not.toContain('🟢');
-        expect(cell.text()).not.toContain('🔴');
+        expect(cell.html()).toContain('mdi-arrow-up-bold');
+        expect(cell.html()).toContain('text-warning');
+        expect(cell.html()).not.toContain('mdi-circle');
+        expect(cell.html()).not.toContain('text-error');
       });
 
-      it('displays the red indicator when the value is above max and beyond tolerance', () => {
+      it('displays the error up arrow when the value is above max and beyond tolerance', () => {
         wrapper = mountComponent({ value: highRedPortion, settings: BASE_SETTINGS });
         const cell = wrapper.find(`[data-testid="${statistic}"]`);
-        expect(cell.text()).toContain('🔴');
-        expect(cell.text()).not.toContain('🟢');
-        expect(cell.text()).not.toContain('🟡');
+        expect(cell.html()).toContain('mdi-arrow-up-bold');
+        expect(cell.html()).toContain('text-error');
+        expect(cell.html()).not.toContain('mdi-circle');
+        expect(cell.html()).not.toContain('text-warning');
       });
     },
   );
@@ -156,21 +159,20 @@ describe('NutritionData', () => {
     it('is not displayed when settings are not provided', () => {
       wrapper = mountComponent({ value: TEST_PORTION });
       const cell = wrapper.find('[data-testid="sugar"]');
-      expect(cell.text()).not.toContain('🟢');
-      expect(cell.text()).not.toContain('🟡');
-      expect(cell.text()).not.toContain('🔴');
+      expect(cell.html()).not.toContain('mdi-circle');
+      expect(cell.html()).not.toContain('mdi-arrow');
     });
 
-    it('displays the green indicator when sugar is at or below the max', () => {
+    it('displays the success circle icon when sugar is at or below the max', () => {
       // TEST_PORTION.sugar = 3, maxDailySugar = 3 → green
       wrapper = mountComponent({ value: TEST_PORTION, settings: { ...BASE_SETTINGS, maxDailySugar: 3 } });
       const cell = wrapper.find('[data-testid="sugar"]');
-      expect(cell.text()).toContain('🟢');
-      expect(cell.text()).not.toContain('🟡');
-      expect(cell.text()).not.toContain('🔴');
+      expect(cell.html()).toContain('mdi-circle');
+      expect(cell.html()).toContain('text-success');
+      expect(cell.html()).not.toContain('mdi-arrow');
     });
 
-    it('displays the yellow indicator when sugar is above max but within tolerance', () => {
+    it('displays the warning up arrow when sugar is above max but within tolerance', () => {
       // TEST_PORTION.sugar = 3, maxDailySugar = 2, tolerance = 60
       // allowedDeviation = 2 * 0.60 = 1.2 → yellow threshold = 3.2 → 3 <= 3.2 → yellow
       wrapper = mountComponent({
@@ -178,12 +180,13 @@ describe('NutritionData', () => {
         settings: { ...BASE_SETTINGS, maxDailySugar: 2, tolerance: 60 },
       });
       const cell = wrapper.find('[data-testid="sugar"]');
-      expect(cell.text()).toContain('🟡');
-      expect(cell.text()).not.toContain('🟢');
-      expect(cell.text()).not.toContain('🔴');
+      expect(cell.html()).toContain('mdi-arrow-up-bold');
+      expect(cell.html()).toContain('text-warning');
+      expect(cell.html()).not.toContain('mdi-circle');
+      expect(cell.html()).not.toContain('text-error');
     });
 
-    it('displays the red indicator when sugar is above max and beyond tolerance', () => {
+    it('displays the error up arrow when sugar is above max and beyond tolerance', () => {
       // TEST_PORTION.sugar = 3, maxDailySugar = 2, tolerance = 10
       // allowedDeviation = 2 * 0.10 = 0.2 → yellow threshold = 2.2 → 3 > 2.2 → red
       wrapper = mountComponent({
@@ -191,9 +194,10 @@ describe('NutritionData', () => {
         settings: { ...BASE_SETTINGS, maxDailySugar: 2, tolerance: 10 },
       });
       const cell = wrapper.find('[data-testid="sugar"]');
-      expect(cell.text()).toContain('🔴');
-      expect(cell.text()).not.toContain('🟢');
-      expect(cell.text()).not.toContain('🟡');
+      expect(cell.html()).toContain('mdi-arrow-up-bold');
+      expect(cell.html()).toContain('text-error');
+      expect(cell.html()).not.toContain('mdi-circle');
+      expect(cell.html()).not.toContain('text-warning');
     });
   });
 });

--- a/src/core/__tests__/nutritional-status.spec.ts
+++ b/src/core/__tests__/nutritional-status.spec.ts
@@ -3,103 +3,103 @@ import { maxOnlyStatus, rangeStatus } from '../nutritional-status';
 
 describe('Nutritional Status', () => {
   describe('for a range', () => {
-    it('is "green" if the value is in the range', () => {
-      expect(rangeStatus(50, 40, 60, 10)).toBe('green');
-      expect(rangeStatus(40, 40, 60, 10)).toBe('green');
-      expect(rangeStatus(60, 40, 60, 10)).toBe('green');
+    it('is "in-zone" if the value is in the range', () => {
+      expect(rangeStatus(50, 40, 60, 10)).toBe('in-zone');
+      expect(rangeStatus(40, 40, 60, 10)).toBe('in-zone');
+      expect(rangeStatus(60, 40, 60, 10)).toBe('in-zone');
     });
 
-    it('is "yellow" if the value is above the max value within tolerance', () => {
-      expect(rangeStatus(60.1, 40, 60, 10)).toBe('yellow');
-      expect(rangeStatus(65, 40, 60, 10)).toBe('yellow');
+    it('is "high-warn" if the value is above the max value within tolerance', () => {
+      expect(rangeStatus(60.1, 40, 60, 10)).toBe('high-warn');
+      expect(rangeStatus(65, 40, 60, 10)).toBe('high-warn');
     });
 
-    it('is "yellow" if the value is below the min value within tolerance', () => {
-      expect(rangeStatus(39.9, 40, 60, 10)).toBe('yellow');
-      expect(rangeStatus(35, 40, 60, 10)).toBe('yellow');
+    it('is "low-warn" if the value is below the min value within tolerance', () => {
+      expect(rangeStatus(39.9, 40, 60, 10)).toBe('low-warn');
+      expect(rangeStatus(35, 40, 60, 10)).toBe('low-warn');
     });
 
-    it('is "red" if the value is below the min value outside of tolerance', () => {
-      expect(rangeStatus(34.9, 40, 60, 10)).toBe('red');
-      expect(rangeStatus(0, 40, 60, 10)).toBe('red');
+    it('is "low-danger" if the value is below the min value outside of tolerance', () => {
+      expect(rangeStatus(34.9, 40, 60, 10)).toBe('low-danger');
+      expect(rangeStatus(0, 40, 60, 10)).toBe('low-danger');
     });
 
-    it('is "red" if the value is above the max value outside of tolerance', () => {
-      expect(rangeStatus(65.1, 40, 60, 10)).toBe('red');
-      expect(rangeStatus(1000, 40, 60, 10)).toBe('red');
+    it('is "high-danger" if the value is above the max value outside of tolerance', () => {
+      expect(rangeStatus(65.1, 40, 60, 10)).toBe('high-danger');
+      expect(rangeStatus(1000, 40, 60, 10)).toBe('high-danger');
     });
 
     it('handles zero tolerance', () => {
-      expect(rangeStatus(50, 40, 60, 0)).toBe('green');
-      expect(rangeStatus(40, 40, 60, 0)).toBe('green');
-      expect(rangeStatus(60, 40, 60, 0)).toBe('green');
-      expect(rangeStatus(39.999, 40, 60, 0)).toBe('red');
-      expect(rangeStatus(60.001, 40, 60, 0)).toBe('red');
+      expect(rangeStatus(50, 40, 60, 0)).toBe('in-zone');
+      expect(rangeStatus(40, 40, 60, 0)).toBe('in-zone');
+      expect(rangeStatus(60, 40, 60, 0)).toBe('in-zone');
+      expect(rangeStatus(39.999, 40, 60, 0)).toBe('low-danger');
+      expect(rangeStatus(60.001, 40, 60, 0)).toBe('high-danger');
     });
 
     it('treats negative tolerance like a zero tolerance', () => {
-      expect(rangeStatus(50, 40, 60, -10)).toBe('green');
-      expect(rangeStatus(40, 40, 60, -10)).toBe('green');
-      expect(rangeStatus(60, 40, 60, -10)).toBe('green');
-      expect(rangeStatus(39.999, 40, 60, -10)).toBe('red');
-      expect(rangeStatus(60.001, 40, 60, -10)).toBe('red');
+      expect(rangeStatus(50, 40, 60, -10)).toBe('in-zone');
+      expect(rangeStatus(40, 40, 60, -10)).toBe('in-zone');
+      expect(rangeStatus(60, 40, 60, -10)).toBe('in-zone');
+      expect(rangeStatus(39.999, 40, 60, -10)).toBe('low-danger');
+      expect(rangeStatus(60.001, 40, 60, -10)).toBe('high-danger');
     });
 
-    it('is "red" if any inputs are NaN, null, or undefined', () => {
-      expect(rangeStatus(NaN, 40, 60, 10)).toBe('red');
-      expect(rangeStatus(50, NaN, 60, 10)).toBe('red');
-      expect(rangeStatus(50, 40, NaN, 10)).toBe('red');
-      expect(rangeStatus(50, 40, 60, NaN)).toBe('red');
-      expect(rangeStatus(null, 40, 60, 10)).toBe('red');
-      expect(rangeStatus(50, null, 60, 10)).toBe('red');
-      expect(rangeStatus(50, 40, null, 10)).toBe('red');
-      expect(rangeStatus(50, 40, 60, null)).toBe('red');
-      expect(rangeStatus(undefined, 40, 60, 10)).toBe('red');
-      expect(rangeStatus(50, undefined, 60, 10)).toBe('red');
-      expect(rangeStatus(50, 40, undefined, 10)).toBe('red');
-      expect(rangeStatus(50, 40, 60, undefined)).toBe('red');
+    it('is null if any inputs are NaN, null, or undefined', () => {
+      expect(rangeStatus(NaN, 40, 60, 10)).toBeNull();
+      expect(rangeStatus(50, NaN, 60, 10)).toBeNull();
+      expect(rangeStatus(50, 40, NaN, 10)).toBeNull();
+      expect(rangeStatus(50, 40, 60, NaN)).toBeNull();
+      expect(rangeStatus(null, 40, 60, 10)).toBeNull();
+      expect(rangeStatus(50, null, 60, 10)).toBeNull();
+      expect(rangeStatus(50, 40, null, 10)).toBeNull();
+      expect(rangeStatus(50, 40, 60, null)).toBeNull();
+      expect(rangeStatus(undefined, 40, 60, 10)).toBeNull();
+      expect(rangeStatus(50, undefined, 60, 10)).toBeNull();
+      expect(rangeStatus(50, 40, undefined, 10)).toBeNull();
+      expect(rangeStatus(50, 40, 60, undefined)).toBeNull();
     });
   });
 
   describe('for a single max value', () => {
-    it('is "green" if the value is at or below the max value', () => {
-      expect(maxOnlyStatus(50, 60, 10)).toBe('green');
-      expect(maxOnlyStatus(0, 60, 10)).toBe('green');
-      expect(maxOnlyStatus(60, 60, 10)).toBe('green');
+    it('is "in-zone" if the value is at or below the max value', () => {
+      expect(maxOnlyStatus(50, 60, 10)).toBe('in-zone');
+      expect(maxOnlyStatus(0, 60, 10)).toBe('in-zone');
+      expect(maxOnlyStatus(60, 60, 10)).toBe('in-zone');
     });
 
-    it('is "yellow" if the value is above the max value within tolerance', () => {
-      expect(maxOnlyStatus(60.1, 60, 10)).toBe('yellow');
-      expect(maxOnlyStatus(66, 60, 10)).toBe('yellow');
+    it('is "high-warn" if the value is above the max value within tolerance', () => {
+      expect(maxOnlyStatus(60.1, 60, 10)).toBe('high-warn');
+      expect(maxOnlyStatus(66, 60, 10)).toBe('high-warn');
     });
 
-    it('is "red" if the value is above the max value outside of tolerance', () => {
-      expect(maxOnlyStatus(66.1, 60, 10)).toBe('red');
-      expect(maxOnlyStatus(234, 60, 10)).toBe('red');
+    it('is "high-danger" if the value is above the max value outside of tolerance', () => {
+      expect(maxOnlyStatus(66.1, 60, 10)).toBe('high-danger');
+      expect(maxOnlyStatus(234, 60, 10)).toBe('high-danger');
     });
 
     it('handles zero tolerance', () => {
-      expect(maxOnlyStatus(40, 60, 0)).toBe('green');
-      expect(maxOnlyStatus(60, 60, 0)).toBe('green');
-      expect(maxOnlyStatus(60.001, 60, 0)).toBe('red');
+      expect(maxOnlyStatus(40, 60, 0)).toBe('in-zone');
+      expect(maxOnlyStatus(60, 60, 0)).toBe('in-zone');
+      expect(maxOnlyStatus(60.001, 60, 0)).toBe('high-danger');
     });
 
     it('treats negative tolerance like a zero tolerance', () => {
-      expect(maxOnlyStatus(40, 60, -10)).toBe('green');
-      expect(maxOnlyStatus(60, 60, -10)).toBe('green');
-      expect(maxOnlyStatus(60.001, 60, -10)).toBe('red');
+      expect(maxOnlyStatus(40, 60, -10)).toBe('in-zone');
+      expect(maxOnlyStatus(60, 60, -10)).toBe('in-zone');
+      expect(maxOnlyStatus(60.001, 60, -10)).toBe('high-danger');
     });
 
-    it('is "red" if any inputs are NaN, null, or undefined', () => {
-      expect(maxOnlyStatus(NaN, 60, 10)).toBe('red');
-      expect(maxOnlyStatus(50, NaN, 10)).toBe('red');
-      expect(maxOnlyStatus(50, 60, NaN)).toBe('red');
-      expect(maxOnlyStatus(null, 60, 10)).toBe('red');
-      expect(maxOnlyStatus(50, null, 10)).toBe('red');
-      expect(maxOnlyStatus(50, 60, null)).toBe('red');
-      expect(maxOnlyStatus(undefined, 60, 10)).toBe('red');
-      expect(maxOnlyStatus(50, undefined, 10)).toBe('red');
-      expect(maxOnlyStatus(50, 60, undefined)).toBe('red');
+    it('is null if any inputs are NaN, null, or undefined', () => {
+      expect(maxOnlyStatus(NaN, 60, 10)).toBeNull();
+      expect(maxOnlyStatus(50, NaN, 10)).toBeNull();
+      expect(maxOnlyStatus(50, 60, NaN)).toBeNull();
+      expect(maxOnlyStatus(null, 60, 10)).toBeNull();
+      expect(maxOnlyStatus(50, null, 10)).toBeNull();
+      expect(maxOnlyStatus(50, 60, null)).toBeNull();
+      expect(maxOnlyStatus(undefined, 60, 10)).toBeNull();
+      expect(maxOnlyStatus(50, undefined, 10)).toBeNull();
+      expect(maxOnlyStatus(50, 60, undefined)).toBeNull();
     });
   });
 });

--- a/src/core/nutritional-status.ts
+++ b/src/core/nutritional-status.ts
@@ -1,11 +1,11 @@
-export type NutritionalStatus = 'green' | 'yellow' | 'red';
+export type NutritionalStatus = 'low-danger' | 'low-warn' | 'in-zone' | 'high-warn' | 'high-danger';
 
 export const rangeStatus = (
   value: number | null | undefined,
   min: number | null | undefined,
   max: number | null | undefined,
   tolerance: number | null | undefined,
-): NutritionalStatus => {
+): NutritionalStatus | null => {
   if (
     value === null ||
     value === undefined ||
@@ -20,23 +20,25 @@ export const rangeStatus = (
     tolerance === undefined ||
     Number.isNaN(tolerance)
   ) {
-    return 'red';
+    return null;
   }
 
   const allowedDeviation = ((max + min) / 2) * (Math.max(tolerance, 0) / 100);
   if (value >= min && value <= max) {
-    return 'green';
-  } else if (value >= min - allowedDeviation && value <= max + allowedDeviation) {
-    return 'yellow';
+    return 'in-zone';
+  } else if (value < min && value >= min - allowedDeviation) {
+    return 'low-warn';
+  } else if (value > max && value <= max + allowedDeviation) {
+    return 'high-warn';
   }
-  return 'red';
+  return value < min ? 'low-danger' : 'high-danger';
 };
 
 export const maxOnlyStatus = (
   value: number | null | undefined,
   max: number | null | undefined,
   tolerance: number | null | undefined,
-): NutritionalStatus => {
+): NutritionalStatus | null => {
   if (
     value === null ||
     value === undefined ||
@@ -48,14 +50,14 @@ export const maxOnlyStatus = (
     tolerance === undefined ||
     Number.isNaN(tolerance)
   ) {
-    return 'red';
+    return null;
   }
 
   const allowedDeviation = max * (Math.max(tolerance, 0) / 100);
   if (value <= max) {
-    return 'green';
+    return 'in-zone';
   } else if (value <= max + allowedDeviation) {
-    return 'yellow';
+    return 'high-warn';
   }
-  return 'red';
+  return 'high-danger';
 };


### PR DESCRIPTION
This update refines the nutritional status indicators to provide more granular and directional feedback. Previously, all deviations from the target range were categorized as generic 'yellow' (warning) or 'red' (danger). This change explicitly distinguishes between values that are too low versus too high.

Key changes include:
*   Introduce new `NutritionalStatus` types: `low-danger`, `low-warn`, `in-zone`, `high-warn`, and `high-danger`.
*   Update core `nutritional-status` functions to accurately map values to these new, more specific status types. Invalid inputs now return `null` instead of a default 'red' status.
*   Replace emoji-based indicators with Vuetify icons in the `NutritionalStatusMarker` component:
    *   `in-zone` uses a success circle (`mdi-circle`).
    *   `low-warn` and `low-danger` use a downward arrow (`mdi-arrow-down-bold`) with warning/error colors.
    *   `high-warn` and `high-danger` use an upward arrow (`mdi-arrow-up-bold`) with warning/error colors.
*   Update all relevant tests to reflect the new status types and their corresponding visual representations, ensuring proper functionality and display.

This enhancement improves user comprehension by clearly indicating whether a nutritional value is too low or too high relative to defined ranges.