### PR TITLE
Extend WeeklyData with avg fat, sugar, sodium

### DIFF
--- a/src/components/planning/__tests__/WeeklySummaryCard.spec.ts
+++ b/src/components/planning/__tests__/WeeklySummaryCard.spec.ts
@@ -16,6 +16,9 @@ const TEST_WEEK: WeeklyData = {
   averageCalories: 2000,
   averageProtein: 100,
   averageCarbs: 250,
+  averageFat: 70,
+  averageSugar: 30,
+  averageSodium: 2000,
 };
 
 const mountComponent = (props: { title: string; week: WeeklyData } = { title: 'This Week', week: TEST_WEEK }) =>

--- a/src/core/__tests__/build-weekly-data.spec.ts
+++ b/src/core/__tests__/build-weekly-data.spec.ts
@@ -2,6 +2,7 @@ import type { MealPlan } from '@/models/meal-plan';
 import type { Settings } from '@/models/settings';
 import { describe, expect, it, vi } from 'vitest';
 import { buildWeeklyData } from '../build-weekly-data';
+import type { Nutrition } from '@/models/nutrition';
 
 const makeSettings = (weekStartDay: 0 | 1 = 0): Settings => ({
   minDailyCalories: 2000,
@@ -19,9 +20,7 @@ const makeSettings = (weekStartDay: 0 | 1 = 0): Settings => ({
   weekStartDay,
 });
 
-type ItemNutrition = { calories: number; protein: number; carbs: number };
-
-const makeMealPlan = (id: string, meals: ItemNutrition[][]): MealPlan => ({
+const makeMealPlan = (id: string, meals: Nutrition[][]): MealPlan => ({
   id,
   date: '2025-12-25',
   meals: meals.map((items, mealIndex) => ({
@@ -32,7 +31,7 @@ const makeMealPlan = (id: string, meals: ItemNutrition[][]): MealPlan => ({
       name: 'Test Food',
       recipeId: 'test-recipe',
       servings: 1,
-      nutrition: { ...nutrition, fat: 0, sugar: 0, sodium: 0 },
+      nutrition,
     })),
   })),
 });
@@ -77,8 +76,8 @@ describe('buildWeeklyData', () => {
 
   it('returns the number of days that have meals', async () => {
     const mealPlans = [
-      makeMealPlan('mp-1', [[{ calories: 500, protein: 30, carbs: 60 }]]),
-      makeMealPlan('mp-2', [[{ calories: 600, protein: 40, carbs: 70 }]]),
+      makeMealPlan('mp-1', [[{ calories: 500, protein: 30, carbs: 60, fat: 10, sodium: 700, sugar: 20 }]]),
+      makeMealPlan('mp-2', [[{ calories: 600, protein: 40, carbs: 70, fat: 20, sodium: 1700, sugar: 35 }]]),
       makeMealPlan('mp-3', []),
     ];
     const getMealPlansForPeriod = vi.fn().mockResolvedValue(mealPlans);
@@ -88,11 +87,14 @@ describe('buildWeeklyData', () => {
 
   it('calculates average calories, protein, and carbs over days with meals', async () => {
     const mealPlans = [
-      makeMealPlan('mp-1', [[{ calories: 300, protein: 20, carbs: 40 }], [{ calories: 200, protein: 11, carbs: 22 }]]),
+      makeMealPlan('mp-1', [
+        [{ calories: 300, protein: 20, carbs: 40, fat: 5, sodium: 300, sugar: 23 }],
+        [{ calories: 200, protein: 11, carbs: 22, fat: 4, sodium: 500, sugar: 12 }],
+      ]),
       makeMealPlan('mp-2', [
         [
-          { calories: 400, protein: 25, carbs: 35 },
-          { calories: 201, protein: 16, carbs: 36 },
+          { calories: 400, protein: 25, carbs: 35, fat: 9, sodium: 800, sugar: 15 },
+          { calories: 201, protein: 16, carbs: 36, fat: 12, sodium: 900, sugar: 18 },
         ],
       ]),
     ];
@@ -102,14 +104,17 @@ describe('buildWeeklyData', () => {
     expect(result.averageCalories).toBe(Math.round((500 + 601) / 2));
     expect(result.averageProtein).toBe(Math.round((31 + 41) / 2));
     expect(result.averageCarbs).toBe(Math.round((62 + 71) / 2));
+    expect(result.averageFat).toBe(Math.round((9 + 21) / 2));
+    expect(result.averageSodium).toBe(Math.round((800 + 1700) / 2));
+    expect(result.averageSugar).toBe(Math.round((35 + 33) / 2));
   });
 
   it('rounds averages to the nearest integer', async () => {
     // 3 days summing to values that produce non-integer averages
     const mealPlans = [
-      makeMealPlan('mp-1', [[{ calories: 100, protein: 10, carbs: 20 }]]),
-      makeMealPlan('mp-2', [[{ calories: 200, protein: 20, carbs: 30 }]]),
-      makeMealPlan('mp-3', [[{ calories: 300, protein: 30, carbs: 40 }]]),
+      makeMealPlan('mp-1', [[{ calories: 100, protein: 10, carbs: 20, fat: 5, sodium: 500, sugar: 10 }]]),
+      makeMealPlan('mp-2', [[{ calories: 200, protein: 20, carbs: 30, fat: 10, sodium: 1000, sugar: 20 }]]),
+      makeMealPlan('mp-3', [[{ calories: 300, protein: 30, carbs: 40, fat: 15, sodium: 1500, sugar: 30 }]]),
     ];
     const getMealPlansForPeriod = vi.fn().mockResolvedValue(mealPlans);
     const result = await buildWeeklyData(START_DATE, makeSettings(), getMealPlansForPeriod);
@@ -124,5 +129,8 @@ describe('buildWeeklyData', () => {
     expect(result.averageCalories).toBe(0);
     expect(result.averageProtein).toBe(0);
     expect(result.averageCarbs).toBe(0);
+    expect(result.averageFat).toBe(0);
+    expect(result.averageSodium).toBe(0);
+    expect(result.averageSugar).toBe(0);
   });
 });

--- a/src/core/__tests__/build-weekly-data.spec.ts
+++ b/src/core/__tests__/build-weekly-data.spec.ts
@@ -85,7 +85,7 @@ describe('buildWeeklyData', () => {
     expect(result.daysWithMeals).toBe(2);
   });
 
-  it('calculates average calories, protein, and carbs over days with meals', async () => {
+  it('calculates average nutritional data over days with meals', async () => {
     const mealPlans = [
       makeMealPlan('mp-1', [
         [{ calories: 300, protein: 20, carbs: 40, fat: 5, sodium: 300, sugar: 23 }],
@@ -121,6 +121,9 @@ describe('buildWeeklyData', () => {
     expect(Number.isInteger(result.averageCalories)).toBe(true);
     expect(Number.isInteger(result.averageProtein)).toBe(true);
     expect(Number.isInteger(result.averageCarbs)).toBe(true);
+    expect(Number.isInteger(result.averageFat)).toBe(true);
+    expect(Number.isInteger(result.averageSodium)).toBe(true);
+    expect(Number.isInteger(result.averageSugar)).toBe(true);
   });
 
   it('returns zero averages when there are no days with meals', async () => {

--- a/src/core/build-weekly-data.ts
+++ b/src/core/build-weekly-data.ts
@@ -21,5 +21,8 @@ export const buildWeeklyData = async (
     averageCalories: Math.round(nutrition.calories / (days || 1)),
     averageProtein: Math.round(nutrition.protein / (days || 1)),
     averageCarbs: Math.round(nutrition.carbs / (days || 1)),
+    averageFat: Math.round(nutrition.fat / (days || 1)),
+    averageSugar: Math.round(nutrition.sugar / (days || 1)),
+    averageSodium: Math.round(nutrition.sodium / (days || 1)),
   };
 };

--- a/src/models/weekly-data.ts
+++ b/src/models/weekly-data.ts
@@ -6,6 +6,6 @@ export interface WeeklyData {
   averageProtein: number;
   averageCarbs: number;
   averageFat: number;
-  overageSugar: number;
-  overageSodium: number;
+  averageSugar: number;
+  averageSodium: number;
 }

--- a/src/models/weekly-data.ts
+++ b/src/models/weekly-data.ts
@@ -5,4 +5,7 @@ export interface WeeklyData {
   averageCalories: number;
   averageProtein: number;
   averageCarbs: number;
+  averageFat: number;
+  overageSugar: number;
+  overageSodium: number;
 }


### PR DESCRIPTION
Extend the `WeeklyData` model and `buildWeeklyData` function to calculate and include average fat, sugar, and sodium values. This provides a more comprehensive overview of weekly nutritional intake. Relates to #354