### PR TITLE
Refactor DailySummaryCard Settings Data Flow

### DIFF
--- a/src/components/planning/DailySummaryCard.vue
+++ b/src/components/planning/DailySummaryCard.vue
@@ -18,18 +18,17 @@
 
 <script setup lang="ts">
 import { dailyMealPlanNutrients } from '@/core/nutritional-calculations';
-import { useSettingsData } from '@/data/settings';
 import type { MealPlan } from '@/models/meal-plan';
 import type { Nutrition } from '@/models/nutrition';
+import type { Settings } from '@/models/settings';
 import { intlFormat } from 'date-fns';
 import { computed } from 'vue';
 
 const props = defineProps<{
   date: Date;
   mealPlan?: MealPlan;
+  settings?: Settings | null;
 }>();
-
-const { settings } = useSettingsData();
 
 const buildMealSummary = (mealPlan: MealPlan): string => {
   let summary = '';

--- a/src/components/planning/__tests__/DailySummaryCard.spec.ts
+++ b/src/components/planning/__tests__/DailySummaryCard.spec.ts
@@ -1,5 +1,4 @@
 import { TEST_MEAL_PLANS } from '@/data/__tests__/test-data';
-import { useSettingsData } from '@/data/settings';
 import type { MealPlan } from '@/models/meal-plan';
 import { mount } from '@vue/test-utils';
 import { intlFormat, parseISO } from 'date-fns';
@@ -8,15 +7,30 @@ import { createVuetify } from 'vuetify';
 import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
 import DailySummaryCard from '../DailySummaryCard.vue';
-
-vi.mock('@/data/settings');
+import type { Settings } from '@/models/settings';
 
 const vuetify = createVuetify({ components, directives });
 
 const TEST_MEAL_PLAN = TEST_MEAL_PLANS[0];
+const TEST_SETTINGS: Settings = {
+  minDailyCalories: 1950,
+  maxDailyCalories: 2150,
+  minDailyProtein: 140,
+  maxDailyProtein: 160,
+  minDailyCarbs: 210,
+  maxDailyCarbs: 235,
+  minDailyFat: 60,
+  maxDailyFat: 75,
+  minDailySodium: 1500,
+  maxDailySodium: 2300,
+  maxDailySugar: 38,
+  tolerance: 10,
+  weekStartDay: 0,
+};
 
-const mountComponent = (props: { date: Date; mealPlan?: MealPlan } = { date: parseISO('2026-04-02') }) =>
-  mount(DailySummaryCard, { props, global: { plugins: [vuetify] } });
+const mountComponent = (
+  props: { date: Date; settings?: Settings; mealPlan?: MealPlan } = { date: parseISO('2026-04-02') },
+) => mount(DailySummaryCard, { props, global: { plugins: [vuetify] } });
 
 describe('Daily Summary Card', () => {
   let wrapper: ReturnType<typeof mountComponent>;
@@ -38,11 +52,6 @@ describe('Daily Summary Card', () => {
     wrapper = mountComponent();
     const title = wrapper.findComponent(components.VCardTitle);
     expect(title.text()).toBe(expectedTitle);
-  });
-
-  it('gets the settings', () => {
-    wrapper = mountComponent();
-    expect(useSettingsData).toHaveBeenCalled();
   });
 
   describe('interactions', () => {
@@ -101,8 +110,7 @@ describe('Daily Summary Card', () => {
       });
 
       it('displays total nutrition information', () => {
-        wrapper = mountComponent({ date: parseISO('2026-04-02'), mealPlan: TEST_MEAL_PLAN });
-        const { settings } = useSettingsData();
+        wrapper = mountComponent({ date: parseISO('2026-04-02'), mealPlan: TEST_MEAL_PLAN, settings: TEST_SETTINGS });
         const nutritionData = wrapper.findComponent({ name: 'NutritionData' });
         expect(nutritionData.exists()).toBe(true);
         expect(nutritionData.props('value')).toEqual({
@@ -113,7 +121,7 @@ describe('Daily Summary Card', () => {
           carbs: 145,
           sugar: 56,
         });
-        expect(nutritionData.props('settings')).toEqual(settings.value);
+        expect(nutritionData.props('settings')).toEqual(TEST_SETTINGS);
       });
     });
 
@@ -127,8 +135,11 @@ describe('Daily Summary Card', () => {
       });
 
       it('displays total nutrition information', () => {
-        wrapper = mountComponent({ date: parseISO('2026-04-02'), mealPlan: PARTIAL_MEAL_PLAN });
-        const { settings } = useSettingsData();
+        wrapper = mountComponent({
+          date: parseISO('2026-04-02'),
+          mealPlan: PARTIAL_MEAL_PLAN,
+          settings: TEST_SETTINGS,
+        });
         const nutritionData = wrapper.findComponent({ name: 'NutritionData' });
         expect(nutritionData.exists()).toBe(true);
         expect(nutritionData.props('value')).toEqual({
@@ -139,7 +150,7 @@ describe('Daily Summary Card', () => {
           carbs: 86,
           sugar: 26,
         });
-        expect(nutritionData.props('settings')).toEqual(settings.value);
+        expect(nutritionData.props('settings')).toEqual(TEST_SETTINGS);
       });
     });
 

--- a/src/pages/planning/__tests__/week.spec.ts
+++ b/src/pages/planning/__tests__/week.spec.ts
@@ -9,6 +9,7 @@ import { createVuetify } from 'vuetify';
 import * as components from 'vuetify/components';
 import * as directives from 'vuetify/directives';
 import week from '../week.vue';
+import { useSettingsData } from '@/data/settings';
 
 vi.mock('vue-router');
 vi.mock('@/data/meal-plans');
@@ -65,6 +66,11 @@ describe('week', () => {
     wrapper = await renderPage();
     const { getMealPlansForPeriod } = useMealPlansData();
     expect(getMealPlansForPeriod).toHaveBeenCalledExactlyOnceWith('2025-12-29', '2026-01-04');
+  });
+
+  it('gets the settings', async () => {
+    wrapper = await renderPage();
+    expect(useSettingsData).toHaveBeenCalledExactlyOnceWith();
   });
 
   describe('when displaying meal plans for the week', () => {

--- a/src/pages/planning/__tests__/week.spec.ts
+++ b/src/pages/planning/__tests__/week.spec.ts
@@ -86,6 +86,7 @@ describe('week', () => {
 
     it('renders a DailySummaryCard for each day in order when all days have a meal plan', async () => {
       const weekPlans = [...TEST_MEAL_PLANS.filter((p) => p.date >= '2025-12-29'), TEST_MEAL_PLAN];
+      const { settings } = useSettingsData();
       (useMealPlansData().getMealPlansForPeriod as Mock).mockResolvedValue(weekPlans);
       wrapper = await renderPage();
 
@@ -94,6 +95,7 @@ describe('week', () => {
       weekDates.forEach((date, i) => {
         expect(format(cards[i]!.props('date'), 'yyyy-MM-dd')).toBe(date);
         expect(cards[i]!.props('mealPlan')).toEqual(weekPlans[i]);
+        expect(cards[i]!.props('settings')).toEqual(settings.value);
       });
     });
 

--- a/src/pages/planning/week.vue
+++ b/src/pages/planning/week.vue
@@ -9,6 +9,7 @@
         <DailySummaryCard
           :date="row.day"
           :mealPlan="row.plan"
+          :settings="settings"
           @click="router.push({ path: '/planning/day', query: { dt: row.iso } })"
         />
       </div>
@@ -25,6 +26,7 @@
 import DailySummaryCard from '@/components/planning/DailySummaryCard.vue';
 import { dateToISO } from '@/core/dates';
 import { useMealPlansData } from '@/data/meal-plans';
+import { useSettingsData } from '@/data/settings';
 import type { MealPlan } from '@/models/meal-plan';
 import { addDays, parseISO } from 'date-fns';
 import { computed, ref, watch } from 'vue';
@@ -32,6 +34,7 @@ import { useRoute, useRouter } from 'vue-router';
 
 type DayRow = { day: Date; iso: string; plan?: MealPlan };
 
+const { settings } = useSettingsData();
 const { getMealPlansForPeriod } = useMealPlansData();
 const route = useRoute();
 const router = useRouter();


### PR DESCRIPTION
Refactor `DailySummaryCard` to receive settings as a prop. Centralize settings data retrieval in the `Week` view for improved component reusability and testability.