### PR TITLE
Add Cursor rules for project conventions and workflows

### DIFF
--- a/.cursor/rules/github-workflows.mdc
+++ b/.cursor/rules/github-workflows.mdc
@@ -1,0 +1,31 @@
+---
+description: GitHub issue templates, PR review format, and subtask workflow for Meal Planner
+alwaysApply: false
+---
+
+# GitHub Workflows
+
+## Issue Templates
+
+Templates for Feature, Task, and Bug issues are in `.github/ISSUE_TEMPLATE/`. Read the appropriate template before creating or suggesting issues to ensure correct structure and frontmatter.
+
+**Subtasks**: Do not create files. Output complete markdown for each subtask in chat first for review. When asked, create issues using the `gh` CLI. Link subtasks to the parent (e.g., "Related to #123").
+
+## Pull Request Reviews
+
+### Comment Format
+
+**Issue:** Describe what needs attention  
+**Suggestion:** Specific improvement with code example  
+**Why:** Reasoning and benefits  
+**Documentation:** Link to best-practices if applicable
+
+### Labels
+
+- 🔒 Security concerns (immediate attention)
+- ⚡ Performance issues/optimizations
+- 🧹 Code cleanup and maintainability
+- 📚 Documentation gaps
+- ✅ Positive feedback
+- 🚨 Critical blockers
+- 💭 Questions for discussion

--- a/.cursor/rules/meal-planner.mdc
+++ b/.cursor/rules/meal-planner.mdc
@@ -1,0 +1,74 @@
+---
+description: Meal Planner project architecture, patterns, and conventions
+alwaysApply: true
+---
+
+# Meal Planner
+
+Vue 3 + TypeScript + Vuetify + Firebase meal planning app using Vite and pnpm.
+
+## Tech Stack
+
+- **Frontend**: Vue 3 (Composition API with `<script setup>`), TypeScript, Vuetify 3
+- **Backend**: Firebase (Authentication, Firestore)
+- **Build**: Vite with auto-imports for components, pages, and routes
+- **Testing**: Vitest + @vue/test-utils
+
+## Project Structure
+
+- `src/components/`: Auto-imported Vue components (multi-word names, no manual imports)
+- `src/pages/`: Auto-converted to routes via `unplugin-vue-router` (e.g., `foods/[id]/index.vue` → `/foods/:id`)
+- `src/layouts/`: Reusable layouts (`default` for main app, `standalone` for login)
+- `src/data/`: Composables for Firestore operations (prefix with `use*`, e.g., `useFoodsData()`)
+- `src/core/`: Business logic composables (`useAuthentication()`, `useRecipeGenerator()`)
+- `src/models/`: TypeScript interfaces for domain entities (`FoodItem`, `Recipe`, `Portion`)
+
+## Key Patterns
+
+### Composables
+
+All data access and business logic uses composables returning reactive state:
+
+```typescript
+export const useFoodsData = () => {
+  const db = useFirestore();
+  const foods = useCollection<FoodItem>(collection(db, 'foods'));
+  const addFood = async (food: FoodItem) => { /* ... */ };
+  return { foods, addFood, updateFood, removeFood };
+};
+```
+
+### Auto-imports
+
+- Components in `src/components/` are globally available (no import statements)
+- Pages in `src/pages/` become routes automatically (folder structure = URL structure)
+- Use `<route lang="yaml">` block in page components for metadata (e.g., `meta: { layout: standalone }`)
+
+### Firebase
+
+- Use VueFire composables: `useFirestore()`, `useCollection()`, `useCurrentUser()`
+- Authentication via `useAuthentication()` in `src/core/authentication.ts`
+- Router has `checkAuthStatus` guard (routes need `meta: { allowAnonymous: true }` to skip auth)
+
+## Code Conventions
+
+- **Components**: Multi-word PascalCase (e.g., `FoodListItem.vue`); pages may use lowercase for URL paths
+- **Composables**: Prefix with `use`, return reactive state + methods
+- **Tests**: Co-located in `__tests__/`, named `*.spec.ts`
+- **Types**: Centralized in `src/models/`
+- **Comments**: Explain "why", not "what"
+
+## Commands
+
+```bash
+pnpm dev              # Dev server (localhost:3000)
+pnpm test             # Run tests once
+pnpm test:dev         # Watch mode
+pnpm test:cov         # Coverage
+pnpm lint             # ESLint
+pnpm build            # Production build
+pnpm emulate          # Firebase emulators with seed data
+pnpm save-seed        # Export emulator data to seed-data/
+```
+
+Single test file: `pnpm vitest run src/path/to/file.spec.ts`

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -1,0 +1,56 @@
+---
+description: Vitest and Vue Test Utils conventions for Meal Planner
+globs: **/*.spec.ts,**/__tests__/**,**/PLAN.md
+alwaysApply: false
+---
+
+# Testing
+
+Vitest with jsdom environment.
+
+## Vuetify in Tests
+
+```typescript
+const vuetify = createVuetify({ components, directives });
+mount(Component, { global: { plugins: [vuetify] } });
+```
+
+## Mocks
+
+- Manual mocks in `src/data/__mocks__/` and `src/core/__mocks__/`
+- Use `vi.mock('@/data/foods')` to swap real composables with mocks
+- Example: `src/data/__mocks__/foods.ts` exports mocked `useFoodsData` with `vi.fn()` methods
+- Mock Firebase/VueFire: `vi.mock('@/core/authentication')`
+- Use `vi.hoisted()` for mocks that must be hoisted before imports (e.g., mocking `firebase/ai` module-level calls)
+
+## Shared Test Utilities
+
+- Test data: `src/data/__tests__/test-data.ts` (`TEST_FOODS`, `TEST_MEAL_PLAN`, `TEST_MEAL_PLANS`, etc.)
+- Form validation helpers: `src/components/__tests__/test-utils.ts` (e.g., `textFieldIsRequired`, `numberInputIsRequired`)
+- Query elements via `data-testid`: `wrapper.findComponent('[data-testid="my-input"]')`
+
+## Test Planning Workflow
+
+When asked to create a test plan for TODO comments (e.g., "create a test plan for TODOs in @file"):
+
+1. Search for `TODO:` comments in the specified file(s)
+2. Analyze surrounding test structure (describe blocks, related cases, setup/teardown, mocks)
+3. Find reference patterns in the same file for similar functionality
+4. Examine source components for events, props, conditional rendering, data flow
+5. Determine implementation status (feature exists vs TDD)
+6. Create `PLAN.md` in the same directory as the test file — do not modify code
+
+### PLAN.md Structure
+
+For each TODO test case: test location, context (scenario, workflow, implementation status), setup steps, test actions, assertions, pattern references (similar tests by line number), and key implementation notes.
+
+Clearly mark each test as **TDD** (feature missing; failing is expected) or **Existing functionality** (should pass immediately).
+
+### Implementation Workflow
+
+1. Create PLAN.md only (no test implementation yet)
+2. User reviews and may edit PLAN.md
+3. Implement tests only when instructed — always read the current PLAN.md first
+
+For TDD tests: implement failing tests as written and note what code changes are needed to pass.
+For existing functionality: tests should pass; investigate failures as potential bugs.


### PR DESCRIPTION
## Summary
- Add always-on `meal-planner.mdc` rule documenting tech stack, project structure, composable patterns, Firebase usage, and dev commands
- Add `testing.mdc` rule for Vitest/Vue Test Utils conventions, mocks, shared test utilities, and the PLAN.md test planning workflow
- Add `github-workflows.mdc` rule for issue templates, subtask workflow, and PR review comment format

## Test plan
- [ ] Verify Cursor loads rules from `.cursor/rules/` in a new agent session
- [ ] Confirm `meal-planner.mdc` applies globally (`alwaysApply: true`)
- [ ] Confirm `testing.mdc` activates for `*.spec.ts` and `__tests__/` files
- [ ] Confirm `github-workflows.mdc` is available on request for GitHub-related tasks


Made with [Cursor](https://cursor.com)